### PR TITLE
Add bandwidth and envelope minimization orderings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,14 @@ set(HEADER_FILES
         include/SparseVizPerformance/SparseVizPerformance.h
         include/Tensor/Base/SparseTensorCOO.h
         include/sort.h
+        include/Matrix/Orderings/GPSOrdering.h
+        include/Matrix/Orderings/RBFS-GLOrdering.h
+        include/Matrix/Orderings/SloanOrdering.h
+        include/Matrix/Orderings/Sloan-MGPSOrdering.h
+        include/Matrix/Orderings/VNSBandOrdering.h
+        include/Matrix/Orderings/DRSAOrdering.h
+        include/Matrix/Orderings/RCMPPOrdering.h
+        include/Matrix/Orderings/SpectralOrdering.h
 )
 
 set(SOURCE_FILES
@@ -167,6 +175,16 @@ set(SOURCE_FILES
         src/SparseVizPerformance/SparseVizPerformance.cpp
         src/Tensor/Base/SparseTensorCOO.cpp
         src/sort.cpp
+        src/Matrix/Orderings/GPSOrderingV2.cpp
+        src/Matrix/Orderings/GPSOrderingV3AGENTIC.cpp
+        src/Matrix/Orderings/RBFS-GLOrderingV2.cpp
+        src/Matrix/Orderings/SloanOrderingV2.cpp
+        src/Matrix/Orderings/Sloan-MGPSOrderingV2.cpp
+        src/Matrix/Orderings/VNSBandOrderingV3.cpp
+        src/Matrix/Orderings/VNSBandOrderingV3+RCM.cpp
+        src/Matrix/Orderings/DRSAOrdering.cpp
+        src/Matrix/Orderings/RCMPPOrdering.cpp
+        src/Matrix/Orderings/SpectralOrdering.cpp
 )
 
 file(READ " -- YOUR CONFIG FILE TO GET PROJECT INFO -- " configContent)
@@ -219,8 +237,9 @@ if(MPI_FOUND)
     )
 endif()
 
-target_link_libraries(SparseViz /home/delbek/sparseviz/lib/libpatoh.a)
-target_link_libraries(SparseViz /home/delbek/sparseviz/lib/libamd.a)
+set(THIRD_PARTY_LIB_DIR "${PROJECT_SOURCE_DIR}/lib")
+target_link_libraries(SparseViz "${THIRD_PARTY_LIB_DIR}/libpatoh.a")
+target_link_libraries(SparseViz "${THIRD_PARTY_LIB_DIR}/libamd.a")
 #target_link_libraries(SparseViz libnuma.a)
 
 target_compile_options(SparseViz PRIVATE -O3)

--- a/include/ConfigurationFiles/SparseVizEngine.cpp
+++ b/include/ConfigurationFiles/SparseVizEngine.cpp
@@ -683,6 +683,41 @@ MatrixOrdering *SparseVizEngine::matrixOrderingFactory(SparseMatrix& matrix, std
     {
         return new AMDOrdering(matrix, orderingName);
     }
+    //made by grkmshn
+    else if (orderingClassName == "GPS")
+    {
+        return new GPSOrdering(matrix, orderingName, orderingParameters);
+    }
+    else if (orderingClassName == "VNSBand")
+    {
+        return new VNSBandOrdering(matrix, orderingName, orderingParameters);
+    }
+    else if (orderingClassName == "RBFS-GL")
+    {
+        return new RBFSGLOrdering(matrix, orderingName, orderingParameters);
+    }
+    else if (orderingClassName == "Sloan")
+    {
+        return new SloanOrdering(matrix, orderingName, orderingParameters);
+    }
+    else if (orderingClassName == "SloanMGPS")
+    {
+        return new MGPSSloanOrdering(matrix, orderingName, orderingParameters);
+    }
+
+    else if (orderingClassName == "SpectralOrdering") {
+        return new SpectralOrdering(matrix, orderingName, orderingParameters);
+    }
+    else if (orderingClassName == "RCMPP")
+    {
+        return new RCMPPOrdering(matrix, orderingName, orderingParameters);
+    }
+    else if (orderingClassName == "DRSA")
+    {
+        return new DRSAOrdering(matrix, orderingName, orderingParameters);
+    }
+
+
 #ifdef RABBIT_AVAILABLE
     else if (orderingClassName == "Rabbit")
     {

--- a/include/ConfigurationFiles/SparseVizEngine.h
+++ b/include/ConfigurationFiles/SparseVizEngine.h
@@ -26,6 +26,17 @@
 #include "MinDegOrdering.h"
 #include "TensorNaturalOrdering.h"
 #include "COOKPartiteOrdering.h"
+
+//grkmshn
+#include "GPSOrdering.h"
+#include "LouvainOrdering.h"
+#include "VNSBandOrdering.h"
+#include "RBFS-GLOrdering.h"
+#include "SloanOrdering.h"
+#include "Sloan-MGPSOrdering.h"
+#include "SpectralOrdering.h"
+#include "RCMPPOrdering.h"
+#include "DRSAOrdering.h"
 #ifdef RABBIT_AVAILABLE
 #include "RabbitOrdering.h"
 #endif

--- a/include/Matrix/Orderings/GPSOrdering.h
+++ b/include/Matrix/Orderings/GPSOrdering.h
@@ -1,0 +1,18 @@
+// GPSOrdering.h
+#pragma once
+#include "MatrixOrdering.h"   // brings SparseMatrix + config.h (vType)
+#include "SparseMatrix.h"
+#include <string>
+#include <vector>
+
+class GPSOrdering : public MatrixOrdering {
+public:
+    GPSOrdering(SparseMatrix& m, std::string name, std::string /*unused*/)
+    : MatrixOrdering(m, std::move(name),
+                     /*rectangularSupport=*/false,
+                     /*patternUnsymmetricSupport=*/false,
+                     /*price=*/3.0) {}
+
+private:
+    void orderingFunction() override;
+};

--- a/include/Matrix/Orderings/RBFS-GLOrdering.h
+++ b/include/Matrix/Orderings/RBFS-GLOrdering.h
@@ -1,0 +1,40 @@
+//
+// Created by orderinggroup on 11/24/25.
+//
+
+#ifndef SPARSEVIZ_RBFSGLORDERING_H
+#define SPARSEVIZ_RBFSGLORDERING_H
+
+#pragma once
+
+#include "MatrixOrdering.h"
+#include "SparseMatrix.h"
+#include "config.h"
+#include "helpers.h"
+
+#include <vector>
+#include <string>
+
+class RBFSGLOrdering : public MatrixOrdering {
+public:
+    RBFSGLOrdering(SparseMatrix& m,
+                   std::string orderingName,
+                   std::string /*unused*/)
+        : MatrixOrdering(m,
+                         std::move(orderingName),
+                         /*rectangularSupport=*/false,
+                         /*patternUnsymmetricSupport=*/false,
+                         /*price=*/3.0) {}
+
+private:
+    void orderingFunction() override;
+
+    // BFS with Gibbs–Lewis priority rule (level, degree)
+    void bfsGL(unsigned root,
+               const std::vector<unsigned>& degree,
+               std::vector<char>& assigned,
+               std::vector<unsigned>& visitOrder);
+};
+
+
+#endif //SPARSEVIZ_RBFSGLORDERING_H

--- a/include/Matrix/Orderings/Sloan-MGPSOrdering.h
+++ b/include/Matrix/Orderings/Sloan-MGPSOrdering.h
@@ -1,0 +1,53 @@
+//
+// Created by orderinggroup on 12/23/25.
+//
+
+#ifndef SPARSEVIZ_SLOAN_MGPSORDERING_H
+#define SPARSEVIZ_SLOAN_MGPSORDERING_H
+
+
+#include "SloanOrdering.h"
+
+class MGPSSloanOrdering final : public SloanOrdering {
+public:
+    MGPSSloanOrdering(SparseMatrix& m,
+                      std::string orderingName,
+                      std::string /*unused*/)
+        : SloanOrdering(m, std::move(orderingName), "") {}
+
+protected:
+    void orderingFunction() override;
+
+private:
+    static void findPseudoPeripheralEndpointsMGPS(
+        unsigned s,
+        const vType* ptr,
+        const vType* ind,
+        unsigned n,
+        const std::vector<unsigned>& degree,
+        unsigned& sOut,
+        unsigned& eOut
+    );
+
+    static void buildLevelStructure(
+    unsigned root,
+    const vType* ptr,
+    const vType* ind,
+    unsigned  n,
+    LevelStructure& out,
+    unsigned widthMin
+    );
+
+    static bool isNeighborOfAnyPicked(
+    unsigned v,
+    const vType* ptr,
+    const vType* ind,
+    const std::vector<unsigned>& picked
+    );
+};
+
+
+
+
+
+#endif //SPARSEVIZ_SLOAN_MGPSORDERING_H

--- a/include/Matrix/Orderings/SloanOrdering.h
+++ b/include/Matrix/Orderings/SloanOrdering.h
@@ -1,0 +1,135 @@
+//
+// Created by grkm on 11/12/25.
+//
+
+#ifndef SPARSEVIZ_SLOANORDERING_H
+#define SPARSEVIZ_SLOANORDERING_H
+
+#include "MatrixOrdering.h"
+
+
+class SloanOrdering  : public MatrixOrdering {
+public:
+    SloanOrdering(SparseMatrix& m,
+                   std::string orderingName,
+                   std::string /*unused*/)
+        : MatrixOrdering(m,
+                         std::move(orderingName),
+                         /*rectangularSupport=*/false,
+                         /*patternUnsymmetricSupport=*/false,
+                         /*price=*/6.0) {}
+
+protected:
+    void orderingFunction() override;
+
+    struct LevelStructure {
+        std::vector<int> level;
+        std::vector<std::vector<unsigned>> byLevel;
+        unsigned depth = 0;
+        unsigned width = 0;
+    };
+
+    // Node bookkeeping (everything per-node in one place)
+    enum class Status : uint8_t {
+        Inactive   = 0, // not adjacent to any active/postactive
+        Preactive  = 1, // adjacent to an active node
+        Active     = 2, // adjacent to a postactive node (but not postactive)
+        Postactive = 3  // already labeled
+    };
+
+    struct NodeInfo {
+        Status   status        = Status::Inactive;
+
+        unsigned degree        = 0;   // m_i in the paper
+        unsigned currentDegree = 0;   // n_i (computed from status + labeled neighborhood)
+        int      distToEnd     = -1;  // d(e,i) from level structure rooted at e
+        int      priority      = 0;   // P_i (integer scoring)
+
+        bool inQueue = false;         // convenience flag for the unordered “priority queue”
+    };
+
+    // Parameters (should be user input later on)
+    int W1 = 2;
+    int W2 = 1;
+
+    static void buildLevelStructure(
+        unsigned root,
+        const vType* ptr,
+        const vType* ind,
+        unsigned n,
+        LevelStructure& out,
+        unsigned widthMin = std::numeric_limits<unsigned>::max() // for “short-circuiting”
+    );
+
+
+    static void initializeNodeInfo(
+        std::vector<NodeInfo>& info,
+        const LevelStructure& Le,                 // already built from endNode (FULL, no abort)
+        unsigned n,
+        const std::vector<unsigned>& degree,
+        const int &W1,
+        const int &W2
+    );
+
+    static void Numbering(
+        unsigned s,
+        const vType* ptr,
+        const vType* ind,
+        unsigned n,
+        int W1,
+        std::vector<NodeInfo>& info,
+        std::vector<unsigned>& eligible,
+        std::vector<unsigned>& labels
+    );
+private:
+
+
+    static void findPseudoPeripheralEndpoints(
+        unsigned s,
+        const vType* ptr,
+        const vType* ind,
+        unsigned n,
+        const std::vector<unsigned>& degree,
+        unsigned& sOut,
+        unsigned& eOut
+    );
+/*
+    static void recomputePriority(
+    unsigned v,
+    unsigned n,
+    std::vector<NodeInfo>& info,
+    int W1,
+    int W2
+);
+
+    static void refreshNode(
+        unsigned v,
+        const vType* ptr,
+        const vType* ind,
+        unsigned n,
+        std::vector<NodeInfo>& info,
+        int W1,
+        int W2
+    );
+
+    static void refreshClosedNeighborhood(
+        unsigned center,
+        const vType* ptr,
+        const vType* ind,
+        unsigned n,
+        std::vector<NodeInfo>& info,
+        int W1,
+        int W2
+    );
+
+    static unsigned computeCurrentDegree(
+    unsigned v,
+    const vType* ptr,
+    const vType* ind,
+    const std::vector<NodeInfo>& info
+);
+*/
+};
+
+
+#endif //SPARSEVIZ_SLOANORDERING_H

--- a/include/Matrix/Orderings/VNSBandOrdering.h
+++ b/include/Matrix/Orderings/VNSBandOrdering.h
@@ -1,0 +1,30 @@
+//
+// Created by grkmshn on 11/20/25.
+//
+
+#ifndef SPARSEVIZ_VNSBANDORDERING_H
+#define SPARSEVIZ_VNSBANDORDERING_H
+
+#pragma once
+#include "MatrixOrdering.h"
+#include "SparseMatrix.h"
+#include <string>
+
+
+class VNSBandOrdering : public MatrixOrdering {
+public:
+    VNSBandOrdering(SparseMatrix& m,
+                    std::string name = "VNSBand",
+                    std::string /*unused*/ = "")
+    : MatrixOrdering(m, name,
+                     /*rectangularSupport=*/false,
+                     /*patternUnsymmetricSupport=*/false, //I am not exactly sure of this, I should ask hoca at some point
+                     /*price=*/9.0) {}
+
+private:
+    void orderingFunction() override;
+};
+
+
+
+#endif //SPARSEVIZ_VNSBANDORDERING_H

--- a/src/Matrix/Orderings/AMDOrdering.cpp
+++ b/src/Matrix/Orderings/AMDOrdering.cpp
@@ -2,7 +2,9 @@
 #include "Parameters.h"
 #include <vector>
 #include <algorithm>
-#include <amd.h>
+extern "C" {
+#include "amd.h"
+}
 
 
 void AMDOrdering::orderingFunction()

--- a/src/Matrix/Orderings/GPSOrderingV2.cpp
+++ b/src/Matrix/Orderings/GPSOrderingV2.cpp
@@ -1,0 +1,722 @@
+
+#include "GPSOrdering.h"
+
+#include <algorithm>
+#include <cassert>
+#include <climits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+// ---------- scratch memory (allocated once per orderingFunction() call) ----------
+struct GPSScratch {
+    unsigned nr = 0;
+
+    // BFS queue backing store (capacity nr). Reused by every BFS in every phase.
+    std::vector<unsigned> bfs_q;
+
+    // Three level-index arrays. During Alg I the roles are:
+    //   lv_level : currently held Lv (persistent through Alg II)
+    //   lu_level : final Lu (persistent through Alg II)
+    //   tmp_level: transient scratch for step-C exploratory BFSes (reset after each)
+    // During Alg II / III, tmp_level is unused.
+    std::vector<int> lv_level;
+    std::vector<int> lu_level;
+    std::vector<int> tmp_level;
+
+    // Parallel touched-vertex lists for the three level arrays. Enables per-
+    // component resets proportional to component size (not nr).
+    std::vector<unsigned> touched_lv;
+    std::vector<unsigned> touched_lu;
+    std::vector<unsigned> touched_tmp;
+
+    // Alg I working buffer: last-level vertex set of Lv, sorted by (deg, id).
+    std::vector<unsigned> lastLevel;
+
+    // Alg II scratch.
+    std::vector<int>      i_of;             // i(w) from GPS paper; -1 outside component
+    std::vector<int>      j_of;             // j(w) = k+1 - level_in_Lu(w)
+    std::vector<char>     placed;           // 1 if w placed on diagonal (i==j)
+    std::vector<char>     rem;              // 1 if w remaining (in_comp && !placed)
+    std::vector<unsigned> touched_ij;       // vertices with i_of/j_of/placed/rem set
+
+    std::vector<int>      counts;           // counts[r] = current |N[r]|
+    std::vector<unsigned> counts_touched;   // levels with nonzero counts[] (for reset)
+
+    std::vector<int>      Hbuf;             // per-subcomponent H[r]
+    std::vector<int>      Lbuf;             // per-subcomponent L[r]
+
+    // Alg II inner CC (connected components of `rem`).
+    std::vector<unsigned> cc_mark;          // cc_mark[v] = subcomp index, UINT_MAX if unset
+    std::vector<unsigned> touched_cc;       // vertices with cc_mark != UINT_MAX
+    std::vector<unsigned> cc_verts;         // flat concatenated subcomp vertex lists
+    std::vector<unsigned> cc_start;         // CSR-style starts, size num_subcomps+1
+    std::vector<unsigned> cc_seeds;         // cc_seeds[k] = first vertex added to subcomp k
+    std::vector<unsigned> cc_order;         // processing order: sort by (size desc, seed asc)
+
+    // Alg III.
+    std::vector<int>      final_level;      // N-level of each component vertex
+    std::vector<unsigned> touched_final;
+    std::vector<char>     labeled;          // 1 if vertex is in `order` (replaces std::find)
+    std::vector<unsigned> touched_labeled;
+    std::vector<unsigned> cand;             // candidate neighbors (reused per parent)
+    std::vector<unsigned> order;            // numbered vertices for current component
+    std::vector<unsigned> level_start_in_order; // level_start[i] = index where level i begins
+
+    // Combined N: flat CSR layout derived from final_level via counting sort.
+    std::vector<unsigned> N_off;
+    std::vector<unsigned> N_flat;
+    std::vector<unsigned> N_cursor;
+
+    // Outer CC decomposition (one pass over the whole graph up front).
+    std::vector<unsigned> comp_id;          // comp_id[v] = outer-component index
+    std::vector<unsigned> comp_start;       // CSR starts
+    std::vector<unsigned> comp_verts;       // vertices per comp, sorted by ascending id
+    std::vector<unsigned> outer_cursor;     // scatter cursor during comp_verts construction
+
+    // Global output.
+    std::vector<unsigned> total_order;
+
+    void resize(unsigned n) {
+        nr = n;
+        bfs_q.resize(n);
+
+        lv_level.assign(n, -1);
+        lu_level.assign(n, -1);
+        tmp_level.assign(n, -1);
+        touched_lv.reserve(n);
+        touched_lu.reserve(n);
+        touched_tmp.reserve(n);
+
+        lastLevel.reserve(n);
+
+        i_of.assign(n, -1);
+        j_of.assign(n, -1);
+        placed.assign(n, 0);
+        rem.assign(n, 0);
+        touched_ij.reserve(n);
+
+        counts.assign(n + 2, 0);
+        counts_touched.reserve(64);
+        Hbuf.assign(n + 2, 0);
+        Lbuf.assign(n + 2, 0);
+
+        cc_mark.assign(n, UINT_MAX);
+        touched_cc.reserve(n);
+        cc_verts.reserve(n);
+        cc_start.reserve(64);
+        cc_seeds.reserve(64);
+        cc_order.reserve(64);
+
+        final_level.assign(n, -1);
+        touched_final.reserve(n);
+        labeled.assign(n, 0);
+        touched_labeled.reserve(n);
+        cand.reserve(128);
+        order.reserve(n);
+        level_start_in_order.reserve(64);
+
+        N_off.reserve(64);
+        N_flat.resize(n);
+        N_cursor.reserve(64);
+
+        comp_id.assign(n, UINT_MAX);
+        comp_start.reserve(64);
+        comp_verts.resize(n);
+        outer_cursor.reserve(64);
+
+        total_order.reserve(n);
+    }
+};
+
+unsigned gps_deg(const unsigned* __restrict ptr, unsigned v) {
+    return ptr[v + 1] - ptr[v];
+}
+
+// BFS from `root`, filling `level[]` (which must be all -1 for reached vertices
+// beforehand; caller's touched-list reset handles this). Records touched
+// vertices. Returns (depth, width) computed inline via level-wave traversal.
+std::pair<int, unsigned> gps_bfs(
+    unsigned root,
+    const unsigned* __restrict ptr,
+    const unsigned* __restrict ind,
+    int* __restrict level,
+    unsigned* __restrict bfs_q,
+    std::vector<unsigned>& touched)
+{
+    unsigned qs = 0, qe = 0;
+    level[root] = 1;
+    touched.push_back(root);
+    bfs_q[qe++] = root;
+    int depth = 1;
+    unsigned width = 1;
+    while (qs < qe) {
+        const unsigned level_end = qe;
+        const unsigned cur_width = level_end - qs;
+        if (cur_width > width) width = cur_width;
+        const int cur_lvl = level[bfs_q[qs]];
+        if (cur_lvl > depth) depth = cur_lvl;
+        while (qs < level_end) {
+            const unsigned u = bfs_q[qs++];
+            for (unsigned p = ptr[u]; p < ptr[u + 1]; ++p) {
+                const unsigned v = ind[p];
+                if (level[v] == -1) {
+                    level[v] = cur_lvl + 1;
+                    touched.push_back(v);
+                    bfs_q[qe++] = v;
+                }
+            }
+        }
+    }
+    return {depth, width};
+}
+
+// Reset a level array to -1 at every touched entry, and clear the touched list.
+void gps_reset_level(int* level, std::vector<unsigned>& touched) {
+    for (unsigned v : touched) level[v] = -1;
+    touched.clear();
+}
+
+// Sort a candidate list by (degree asc, id asc). V1's `by_deg`.
+void gps_sort_by_deg(std::vector<unsigned>& xs,
+                                   const unsigned* __restrict ptr) {
+    std::ranges::sort(xs.begin(), xs.end(), [ptr](unsigned const a, unsigned const b) {
+        const unsigned da = gps_deg(ptr, a);
+        const unsigned db = gps_deg(ptr, b);
+        if (da != db) return da < db;
+        return a < b;
+    });
+}
+
+} // namespace
+
+
+void GPSOrdering::orderingFunction() {
+    if (rowIPermutation || colIPermutation) return;
+
+    const unsigned nr = getMatrix().getRowCount();
+    const unsigned nc = getMatrix().getColCount();
+    const unsigned* __restrict ptr = getMatrix().getPtr();
+    const unsigned* __restrict ind = getMatrix().getInd();
+
+    if (nr == 0) {
+        rowIPermutation = new vType[0];
+        colIPermutation = new vType[nc];
+        for (unsigned j = 0; j < nc; ++j) colIPermutation[j] = static_cast<vType>(j);
+        return;
+    }
+
+    GPSScratch sc;
+    sc.resize(nr);
+
+    // ------------------------------------------------------------------
+    // Outer CC decomposition: label every vertex with its component id via
+    // BFS from each unassigned seed in ascending id. Then build comp_verts
+    // sorted by ascending id within each component.
+    // ------------------------------------------------------------------
+    unsigned num_comps = 0;
+    for (unsigned s = 0; s < nr; ++s) {
+        if (sc.comp_id[s] != UINT_MAX) continue;
+        unsigned qs = 0, qe = 0;
+        sc.bfs_q[qe++] = s;
+        sc.comp_id[s] = num_comps;
+        while (qs < qe) {
+            const unsigned u = sc.bfs_q[qs++];
+            for (unsigned p = ptr[u]; p < ptr[u + 1]; ++p) {
+                const unsigned v = ind[p];
+                if (sc.comp_id[v] == UINT_MAX) {
+                    sc.comp_id[v] = num_comps;
+                    sc.bfs_q[qe++] = v;
+                }
+            }
+        }
+        ++num_comps;
+    }
+
+    sc.comp_start.assign(num_comps + 1, 0);
+    for (unsigned v = 0; v < nr; ++v) sc.comp_start[sc.comp_id[v] + 1]++;
+    for (unsigned c = 1; c <= num_comps; ++c) sc.comp_start[c] += sc.comp_start[c - 1];
+
+    sc.outer_cursor.assign(sc.comp_start.begin(), sc.comp_start.end());
+    for (unsigned v = 0; v < nr; ++v) {
+        const unsigned cid = sc.comp_id[v];
+        sc.comp_verts[sc.outer_cursor[cid]++] = v;
+    }
+
+    // ------------------------------------------------------------------
+    // Process each component in ascending-seed-id order (matches V1's
+    // for-s-in-0..nr outer loop visit order).
+    // ------------------------------------------------------------------
+    for (unsigned cid = 0; cid < num_comps; ++cid) {
+        const unsigned comp_begin = sc.comp_start[cid];
+        const unsigned comp_end   = sc.comp_start[cid + 1];
+        const unsigned n_comp     = comp_end - comp_begin;
+
+        // Isolated / singleton component -> append seed directly (V1 fast path).
+        if (n_comp == 1) {
+            sc.total_order.push_back(sc.comp_verts[comp_begin]);
+            continue;
+        }
+
+        // --------------------------------------------------------------
+        // Algorithm I: pseudo-diameter endpoints.
+        // --------------------------------------------------------------
+
+        // A. v := min-degree vertex in component (iterated in ascending id;
+        unsigned v_cur = sc.comp_verts[comp_begin];
+        unsigned v_deg = gps_deg(ptr, v_cur);
+        for (unsigned i = comp_begin + 1; i < comp_end; ++i) {
+            const unsigned c = sc.comp_verts[i];
+            const unsigned d = gps_deg(ptr, c);
+            if (d < v_deg) { v_deg = d; v_cur = c; }
+        }
+
+        // B. Build Lv.
+        auto Lv_dw = gps_bfs(v_cur, ptr, ind,
+                             sc.lv_level.data(), sc.bfs_q.data(), sc.touched_lv);
+        int      Lv_depth = Lv_dw.first;
+        unsigned Lv_width = Lv_dw.second;
+
+        // C/D fused: iterate sorted S once tracking (min_width, best_u). If any
+        // s improves depth, promote and restart outer. Otherwise one final BFS
+        // from best_u materializes Lu.
+        unsigned u_best = v_cur;
+        int      Lu_depth = Lv_depth;
+        unsigned Lu_width = Lv_width;
+        while (true) {
+            // Build S from touched_lv, filtered to last level.
+            sc.lastLevel.clear();
+            for (unsigned w : sc.touched_lv) {
+                if (sc.lv_level[w] == Lv_depth) sc.lastLevel.push_back(w);
+            }
+            gps_sort_by_deg(sc.lastLevel, ptr);
+
+            unsigned best_u_local = sc.lastLevel.empty() ? v_cur : sc.lastLevel[0];
+            unsigned best_w_local = UINT_MAX;
+            bool progressed = false;
+            for (unsigned s : sc.lastLevel) {
+                auto dw = gps_bfs(s, ptr, ind,
+                                  sc.tmp_level.data(), sc.bfs_q.data(),
+                                  sc.touched_tmp);
+                const int      s_depth = dw.first;
+                const unsigned s_width = dw.second;
+                if (s_depth > Lv_depth) {
+                    // Promote s to the new v. Swap tmp <-> lv storage so the
+                    // new Lv data lives in lv_level without an O(n) copy.
+                    gps_reset_level(sc.lv_level.data(), sc.touched_lv);
+                    sc.lv_level.swap(sc.tmp_level);
+                    sc.touched_lv.swap(sc.touched_tmp);
+                    v_cur    = s;
+                    Lv_depth = s_depth;
+                    Lv_width = s_width;
+                    progressed = true;
+                    break;
+                }
+                if (s_width < best_w_local) {
+                    best_w_local = s_width;
+                    best_u_local = s;
+                }
+                gps_reset_level(sc.tmp_level.data(), sc.touched_tmp);
+            }
+            if (!progressed) {
+                u_best = best_u_local;
+                auto dw = gps_bfs(u_best, ptr, ind,
+                                  sc.lu_level.data(), sc.bfs_q.data(),
+                                  sc.touched_lu);
+                Lu_depth = dw.first;
+                Lu_width = dw.second;
+                break;
+            }
+        }
+
+        const unsigned u_vert = u_best;
+        const unsigned v_vert = v_cur;
+
+        // --------------------------------------------------------------
+        // Algorithm II: combine Lv and Lu into a single level structure N.
+        // --------------------------------------------------------------
+        const int k_total = std::max(Lv_depth, Lu_depth);
+
+        // 1. i_of(w) = lv_level[w]; j_of(w) = k+1 - lu_level[w].
+        sc.touched_ij.clear();
+        for (unsigned i = comp_begin; i < comp_end; ++i) {
+            const unsigned w = sc.comp_verts[i];
+            const int iv = sc.lv_level[w];
+            const int ju = sc.lu_level[w];
+            if (iv > 0 && ju > 0) {
+                sc.i_of[w] = iv;
+                sc.j_of[w] = k_total + 1 - ju;
+                sc.touched_ij.push_back(w);
+            }
+        }
+
+        // 2. Diagonal placement.
+        sc.touched_final.clear();
+        sc.counts_touched.clear();
+        for (unsigned w : sc.touched_ij) {
+            if (sc.i_of[w] == sc.j_of[w]) {
+                sc.placed[w] = 1;
+                sc.final_level[w] = sc.i_of[w];
+                sc.touched_final.push_back(w);
+                const int r = sc.i_of[w];
+                if (sc.counts[r] == 0) sc.counts_touched.push_back(static_cast<unsigned>(r));
+                sc.counts[r]++;
+            }
+        }
+
+        // 3. rem = in_comp && !placed (within touched_ij, which is exactly the
+        // set of component vertices that had valid i_of/j_of).
+        for (unsigned w : sc.touched_ij) {
+            if (!sc.placed[w]) sc.rem[w] = 1;
+        }
+
+        // 4. Inner CC over rem. Seed order: ascending vertex id within component,
+        // which makes cc_seeds[k] equal V1's per-subcomponent first vertex in
+        // BFS order (seed == lowest-id vertex in the subcomponent).
+        sc.touched_cc.clear();
+        sc.cc_verts.clear();
+        sc.cc_start.clear();
+        sc.cc_seeds.clear();
+        sc.cc_order.clear();
+        sc.cc_start.push_back(0);
+
+        for (unsigned i = comp_begin; i < comp_end; ++i) {
+            const unsigned seed = sc.comp_verts[i];
+            if (!sc.rem[seed] || sc.cc_mark[seed] != UINT_MAX) continue;
+
+            const auto sub_id = static_cast<unsigned>(sc.cc_seeds.size());
+            unsigned qs = 0, qe = 0;
+            sc.bfs_q[qe++] = seed;
+            sc.cc_mark[seed] = sub_id;
+            sc.touched_cc.push_back(seed);
+            sc.cc_verts.push_back(seed);
+            while (qs < qe) {
+                const unsigned u = sc.bfs_q[qs++];
+                for (unsigned p = ptr[u]; p < ptr[u + 1]; ++p) {
+                    const unsigned w = ind[p];
+                    if (sc.rem[w] && sc.cc_mark[w] == UINT_MAX) {
+                        sc.cc_mark[w] = sub_id;
+                        sc.touched_cc.push_back(w);
+                        sc.bfs_q[qe++] = w;
+                        sc.cc_verts.push_back(w);
+                    }
+                }
+            }
+            sc.cc_seeds.push_back(seed);
+            sc.cc_start.push_back(static_cast<unsigned>(sc.cc_verts.size()));
+        }
+        const auto num_sub = static_cast<unsigned>(sc.cc_seeds.size());
+
+        // 5. Sort subcomponents by (size desc, seed asc).
+        sc.cc_order.resize(num_sub);
+        for (unsigned i = 0; i < num_sub; ++i) sc.cc_order[i] = i;
+        std::ranges::sort(sc.cc_order.begin(), sc.cc_order.end(),
+            [&](unsigned a, unsigned b) {
+                const unsigned sa = sc.cc_start[a + 1] - sc.cc_start[a];
+                const unsigned sb = sc.cc_start[b + 1] - sc.cc_start[b];
+                if (sa != sb) return sa > sb;
+                return sc.cc_seeds[a] < sc.cc_seeds[b];
+            });
+
+        // 6. For each subcomponent, compute H/L, decide FIRST vs SECOND, assign
+        // final_level[w], update counts[r]. Record firstChoice from the first
+        // processed subcomponent (matches V1).
+        bool firstChoiceFirst = true;
+        bool first_choice_set = false;
+
+        for (unsigned idx : sc.cc_order) {
+            const unsigned start = sc.cc_start[idx];
+            const unsigned end   = sc.cc_start[idx + 1];
+
+            // Populate H[r], L[r] for this subcomponent.
+            for (unsigned i = start; i < end; ++i) {
+                const unsigned w = sc.cc_verts[i];
+                sc.Hbuf[sc.i_of[w]]++;
+                sc.Lbuf[sc.j_of[w]]++;
+            }
+
+            // V1 computes max over ALL r in 1..k_total (no "H[r]>0" guard, despite
+            // the paper's description). Preserve exactly.
+            int h0 = 0, l0 = 0;
+            for (int r = 1; r <= k_total; ++r) {
+                const int vh = sc.counts[r] + sc.Hbuf[r];
+                const int vl = sc.counts[r] + sc.Lbuf[r];
+                if (vh > h0) h0 = vh;
+                if (vl > l0) l0 = vl;
+            }
+
+            bool choose_first;
+            if (h0 < l0)      choose_first = true;
+            else if (l0 < h0) choose_first = false;
+            else {
+                // Tie on min-max: break by Lv vs Lu width. Tie-of-ties -> FIRST.
+                if (Lv_width < Lu_width)      choose_first = true;
+                else if (Lu_width < Lv_width) choose_first = false;
+                else                           choose_first = true;
+            }
+
+            if (!first_choice_set) {
+                firstChoiceFirst = choose_first;
+                first_choice_set = true;
+            }
+
+            // Assign final_level + bump counts.
+            if (choose_first) {
+                for (unsigned i = start; i < end; ++i) {
+                    const unsigned w = sc.cc_verts[i];
+                    const int r = sc.i_of[w];
+                    sc.final_level[w] = r;
+                    sc.touched_final.push_back(w);
+                    if (sc.counts[r] == 0) sc.counts_touched.push_back(static_cast<unsigned>(r));
+                    sc.counts[r]++;
+                }
+            } else {
+                for (unsigned i = start; i < end; ++i) {
+                    const unsigned w = sc.cc_verts[i];
+                    const int r = sc.j_of[w];
+                    sc.final_level[w] = r;
+                    sc.touched_final.push_back(w);
+                    if (sc.counts[r] == 0) sc.counts_touched.push_back(static_cast<unsigned>(r));
+                    sc.counts[r]++;
+                }
+            }
+
+            // Zero H, L for next subcomponent using this subcomponent's vertex
+            // list (idempotent: setting to 0 is safe even for repeated r).
+            for (unsigned i = start; i < end; ++i) {
+                const unsigned w = sc.cc_verts[i];
+                sc.Hbuf[sc.i_of[w]] = 0;
+                sc.Lbuf[sc.j_of[w]] = 0;
+            }
+        }
+
+        // --------------------------------------------------------------
+        // Algorithm III: numbering.
+        // --------------------------------------------------------------
+
+        // A. Swap u/v and reverse level indices if deg(u) < deg(v).
+        unsigned u_eff = u_vert, v_eff = v_vert;
+        bool swapped = false;
+        if (gps_deg(ptr, u_eff) < gps_deg(ptr, v_eff)) {
+            std::swap(u_eff, v_eff);
+            swapped = true;
+
+            // Flip level indices in-place for every placed vertex.
+            for (unsigned w : sc.touched_final) {
+                sc.final_level[w] = k_total + 1 - sc.final_level[w];
+            }
+
+            // Rebuild counts from scratch (index r becomes k+1-r).
+            for (unsigned r : sc.counts_touched) sc.counts[r] = 0;
+            sc.counts_touched.clear();
+            for (unsigned w : sc.touched_final) {
+                const int r = sc.final_level[w];
+                if (sc.counts[r] == 0) sc.counts_touched.push_back(static_cast<unsigned>(r));
+                sc.counts[r]++;
+            }
+        }
+
+        // Build N_off + N_flat from final_level via counting sort.
+        sc.N_off.assign(static_cast<size_t>(k_total + 2), 0);
+        for (unsigned r : sc.counts_touched) sc.N_off[r] = static_cast<unsigned>(sc.counts[r]);
+
+        unsigned acc = 0;
+        for (int r = 1; r <= k_total; ++r) {
+            const unsigned sz = sc.N_off[r];
+            sc.N_off[r] = acc;
+            acc += sz;
+        }
+        sc.N_off[k_total + 1] = acc;
+
+        sc.N_cursor.assign(sc.N_off.begin(), sc.N_off.end());
+        for (unsigned i = comp_begin; i < comp_end; ++i) {
+            const unsigned w = sc.comp_verts[i];
+            const int r = sc.final_level[w];
+            if (r >= 1 && r <= k_total) {
+                sc.N_flat[sc.N_cursor[r]++] = w;
+            }
+        }
+
+        // B. Number level N_1.
+        sc.order.clear();
+        sc.touched_labeled.clear();
+        sc.level_start_in_order.assign(static_cast<size_t>(k_total + 2), 0);
+        sc.level_start_in_order[1] = 0;
+
+        //  B.1 Seed with v_eff if it lives in level 1 (V1: `if level_of[v]==1`).
+        if (sc.final_level[v_eff] == 1) {
+            sc.order.push_back(v_eff);
+            sc.labeled[v_eff] = 1;
+            sc.touched_labeled.push_back(v_eff);
+        }
+
+        //  B.2 + B.3: forward-walk intra-level-1 expansion + leftover pickup.
+        //  V1's semantics for level 1 are full B.2 iteration (every level-1
+        //  vertex that gains unnumbered level-1 neighbors gets expanded)
+        //  followed by leftover seed and loop.
+        size_t scan = 0;
+        while (true) {
+            while (scan < sc.order.size()) {
+                const unsigned w = sc.order[scan++];
+                if (sc.final_level[w] != 1) continue;
+                sc.cand.clear();
+                for (unsigned p = ptr[w]; p < ptr[w + 1]; ++p) {
+                    const unsigned x = ind[p];
+                    if (sc.final_level[x] == 1 && !sc.labeled[x]) sc.cand.push_back(x);
+                }
+                if (sc.cand.empty()) continue;
+                gps_sort_by_deg(sc.cand, ptr);
+                for (unsigned x : sc.cand) {
+                    sc.labeled[x] = 1;
+                    sc.touched_labeled.push_back(x);
+                    sc.order.push_back(x);
+                }
+            }
+            //  Leftover pickup: min-(deg,id) unlabeled vertex in N_1.
+            unsigned lo_best = UINT_MAX;
+            unsigned lo_deg  = UINT_MAX;
+            for (unsigned idx = sc.N_off[1]; idx < sc.N_off[2]; ++idx) {
+                const unsigned x = sc.N_flat[idx];
+                if (sc.labeled[x]) continue;
+                const unsigned d = gps_deg(ptr, x);
+                if (d < lo_deg || (d == lo_deg && x < lo_best)) {
+                    lo_deg  = d;
+                    lo_best = x;
+                }
+            }
+            if (lo_best == UINT_MAX) break;
+            sc.labeled[lo_best] = 1;
+            sc.touched_labeled.push_back(lo_best);
+            sc.order.push_back(lo_best);
+            // Re-enter forward walk; scan continues from where it was, which
+            // is now pointing at (or just past) the just-appended leftover.
+        }
+        sc.level_start_in_order[2] = static_cast<unsigned>(sc.order.size());
+
+        // C. Number levels N_2 .. N_k.
+        for (int i = 2; i <= k_total; ++i) {
+            const unsigned li_m1_start = sc.level_start_in_order[i - 1];
+            const unsigned li_m1_end   = sc.level_start_in_order[i];
+
+            // C.1 Single forward walk across level-(i-1) parents in `order`.
+            //     The natural iteration order gives V1's "lowest-numbered
+            //     parent with unnumbered level-i neighbors".
+            for (unsigned si = li_m1_start; si < li_m1_end; ++si) {
+                const unsigned parent = sc.order[si];
+                sc.cand.clear();
+                for (unsigned p = ptr[parent]; p < ptr[parent + 1]; ++p) {
+                    const unsigned x = ind[p];
+                    if (sc.final_level[x] == i && !sc.labeled[x]) sc.cand.push_back(x);
+                }
+                if (sc.cand.empty()) continue;
+                gps_sort_by_deg(sc.cand, ptr);
+                for (unsigned x : sc.cand) {
+                    sc.labeled[x] = 1;
+                    sc.touched_labeled.push_back(x);
+                    sc.order.push_back(x);
+                }
+            }
+
+            // C.2 Leftover pickup. NOTE: V1 deliberately does NOT perform the
+            //     full B.2 intra-level iteration for level i >= 2 -- only a
+            //     seed + one-hop expansion. Preserve that quirk exactly.
+            while (true) {
+                unsigned lo_best = UINT_MAX;
+                unsigned lo_deg  = UINT_MAX;
+                for (unsigned idx = sc.N_off[i]; idx < sc.N_off[i + 1]; ++idx) {
+                    const unsigned x = sc.N_flat[idx];
+                    if (sc.labeled[x]) continue;
+                    const unsigned d = gps_deg(ptr, x);
+                    if (d < lo_deg || (d == lo_deg && x < lo_best)) {
+                        lo_deg  = d;
+                        lo_best = x;
+                    }
+                }
+                if (lo_best == UINT_MAX) break;
+                sc.labeled[lo_best] = 1;
+                sc.touched_labeled.push_back(lo_best);
+                sc.order.push_back(lo_best);
+
+                // One-hop expansion from lo_best within level i.
+                sc.cand.clear();
+                for (unsigned p = ptr[lo_best]; p < ptr[lo_best + 1]; ++p) {
+                    const unsigned x = ind[p];
+                    if (sc.final_level[x] == i && !sc.labeled[x]) sc.cand.push_back(x);
+                }
+                if (!sc.cand.empty()) {
+                    gps_sort_by_deg(sc.cand, ptr);
+                    for (unsigned x : sc.cand) {
+                        sc.labeled[x] = 1;
+                        sc.touched_labeled.push_back(x);
+                        sc.order.push_back(x);
+                    }
+                }
+            }
+            sc.level_start_in_order[i + 1] = static_cast<unsigned>(sc.order.size());
+        }
+
+        // D. GPS reversal rule.
+        const bool needReverse =
+            ( swapped && !firstChoiceFirst) ||
+            (!swapped &&  firstChoiceFirst);
+        if (needReverse) {
+            std::ranges::reverse(sc.order.begin(), sc.order.end());
+        }
+
+        // Append this component's order into the global total.
+        for (unsigned w : sc.order) sc.total_order.push_back(w);
+
+        // --------------------------------------------------------------
+        // Per-component scratch reset (proportional to component size).
+        // --------------------------------------------------------------
+        gps_reset_level(sc.lv_level.data(),  sc.touched_lv);
+        gps_reset_level(sc.lu_level.data(),  sc.touched_lu);
+        gps_reset_level(sc.tmp_level.data(), sc.touched_tmp);
+
+        for (unsigned w : sc.touched_ij) {
+            sc.i_of[w]   = -1;
+            sc.j_of[w]   = -1;
+            sc.placed[w] = 0;
+            sc.rem[w]    = 0;
+        }
+        sc.touched_ij.clear();
+
+        for (unsigned r : sc.counts_touched) sc.counts[r] = 0;
+        sc.counts_touched.clear();
+
+        for (unsigned w : sc.touched_final) sc.final_level[w] = -1;
+        sc.touched_final.clear();
+
+        for (unsigned w : sc.touched_labeled) sc.labeled[w] = 0;
+        sc.touched_labeled.clear();
+
+        for (unsigned w : sc.touched_cc) sc.cc_mark[w] = UINT_MAX;
+        sc.touched_cc.clear();
+    }
+
+    // V1-compatible safety: append any vertex never written to total_order
+    // (should not occur with correct CC, but preserve behavior).
+    if (sc.total_order.size() != nr) {
+        std::vector<char> seen(nr, 0);
+        for (unsigned w : sc.total_order) seen[w] = 1;
+        for (unsigned v = 0; v < nr; ++v) {
+            if (!seen[v]) sc.total_order.push_back(v);
+        }
+    }
+    assert(sc.total_order.size() == nr);
+
+    // Write row permutation: newPos -> vertex, so rowIPermutation[v] = newPos.
+    rowIPermutation = new vType[nr];
+    for (unsigned newPos = 0; newPos < nr; ++newPos) {
+        rowIPermutation[sc.total_order[newPos]] = static_cast<vType>(newPos);
+    }
+
+    // Column permutation: mirror rows when square, else identity.
+    colIPermutation = new vType[nc];
+    if (nr == nc) {
+        for (unsigned v = 0; v < nc; ++v) colIPermutation[v] = rowIPermutation[v];
+    } else {
+        for (unsigned j = 0; j < nc; ++j) colIPermutation[j] = static_cast<vType>(j);
+    }
+}

--- a/src/Matrix/Orderings/GPSOrderingV3AGENTIC.cpp
+++ b/src/Matrix/Orderings/GPSOrderingV3AGENTIC.cpp
@@ -1,0 +1,770 @@
+
+#include "GPSOrdering.h"
+
+#include <algorithm>
+#include <cassert>
+#include <climits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+// ---------- scratch memory (allocated once per orderingFunction() call) ----------
+struct GPSScratch {
+    unsigned nr = 0;
+
+    // BFS queue backing store (capacity nr). Reused by every BFS in every phase.
+    std::vector<unsigned> bfs_q;
+
+    // Three level-index arrays. During Alg I the roles are:
+    //   lv_level : currently held Lv (persistent through Alg II)
+    //   lu_level : final Lu (persistent through Alg II)
+    //   tmp_level: transient scratch for step-C exploratory BFSes (reset after each)
+    // During Alg II / III, tmp_level is unused.
+    std::vector<int> lv_level;
+    std::vector<int> lu_level;
+    std::vector<int> tmp_level;
+
+    // Parallel touched-vertex lists for the three level arrays. Enables per-
+    // component resets proportional to component size (not nr).
+    std::vector<unsigned> touched_lv;
+    std::vector<unsigned> touched_lu;
+    std::vector<unsigned> touched_tmp;
+
+    // Alg I working buffer: last-level vertex set of Lv, sorted by (deg, id).
+    std::vector<unsigned> lastLevel;
+
+    // Alg II scratch.
+    std::vector<int>      i_of;             // i(w) from GPS paper; -1 outside component
+    std::vector<int>      j_of;             // j(w) = k+1 - level_in_Lu(w)
+    std::vector<char>     placed;           // 1 if w placed on diagonal (i==j)
+    std::vector<char>     rem;              // 1 if w remaining (in_comp && !placed)
+    std::vector<unsigned> touched_ij;       // vertices with i_of/j_of/placed/rem set
+
+    std::vector<int>      counts;           // counts[r] = current |N[r]|
+    std::vector<unsigned> counts_touched;   // levels with nonzero counts[] (for reset)
+
+    std::vector<int>      Hbuf;             // per-subcomponent H[r]
+    std::vector<int>      Lbuf;             // per-subcomponent L[r]
+
+    // Alg II inner CC (connected components of `rem`).
+    std::vector<unsigned> cc_mark;          // cc_mark[v] = subcomp index, UINT_MAX if unset
+    std::vector<unsigned> touched_cc;       // vertices with cc_mark != UINT_MAX
+    std::vector<unsigned> cc_verts;         // flat concatenated subcomp vertex lists
+    std::vector<unsigned> cc_start;         // CSR-style starts, size num_subcomps+1
+    std::vector<unsigned> cc_seeds;         // cc_seeds[k] = first vertex added to subcomp k
+    std::vector<unsigned> cc_order;         // processing order: sort by (size desc, seed asc)
+
+    // Alg III.
+    std::vector<int>      final_level;      // N-level of each component vertex
+    std::vector<unsigned> touched_final;
+    std::vector<char>     labeled;          // 1 if vertex is in `order` (replaces std::find)
+    std::vector<unsigned> touched_labeled;
+    std::vector<unsigned> cand;             // candidate neighbors (reused per parent)
+    std::vector<unsigned> order;            // numbered vertices for current component
+    std::vector<unsigned> level_start_in_order; // level_start[i] = index where level i begins
+
+    // Combined N: flat CSR layout derived from final_level via counting sort.
+    std::vector<unsigned> N_off;
+    std::vector<unsigned> N_flat;
+    std::vector<unsigned> N_cursor;
+    // Counting-sort scratch for per-level (deg, id) sort of N_flat slices.
+    std::vector<unsigned> deg_count;
+    std::vector<unsigned> sort_scratch;
+
+    // Outer CC decomposition (one pass over the whole graph up front).
+    std::vector<unsigned> comp_id;          // comp_id[v] = outer-component index
+    std::vector<unsigned> comp_start;       // CSR starts
+    std::vector<unsigned> comp_verts;       // vertices per comp, sorted by ascending id
+    std::vector<unsigned> outer_cursor;     // scatter cursor during comp_verts construction
+
+    // Global output.
+    std::vector<unsigned> total_order;
+
+    void resize(unsigned n) {
+        nr = n;
+        bfs_q.resize(n);
+
+        lv_level.assign(n, -1);
+        lu_level.assign(n, -1);
+        tmp_level.assign(n, -1);
+        touched_lv.reserve(n);
+        touched_lu.reserve(n);
+        touched_tmp.reserve(n);
+
+        lastLevel.reserve(n);
+
+        i_of.assign(n, -1);
+        j_of.assign(n, -1);
+        placed.assign(n, 0);
+        rem.assign(n, 0);
+        touched_ij.reserve(n);
+
+        counts.assign(n + 2, 0);
+        counts_touched.reserve(64);
+        Hbuf.assign(n + 2, 0);
+        Lbuf.assign(n + 2, 0);
+
+        cc_mark.assign(n, UINT_MAX);
+        touched_cc.reserve(n);
+        cc_verts.reserve(n);
+        cc_start.reserve(64);
+        cc_seeds.reserve(64);
+        cc_order.reserve(64);
+
+        final_level.assign(n, -1);
+        touched_final.reserve(n);
+        labeled.assign(n, 0);
+        touched_labeled.reserve(n);
+        cand.reserve(128);
+        order.reserve(n);
+        level_start_in_order.reserve(64);
+
+        N_off.reserve(64);
+        N_flat.resize(n);
+        N_cursor.reserve(64);
+
+        comp_id.assign(n, UINT_MAX);
+        comp_start.reserve(64);
+        comp_verts.resize(n);
+        outer_cursor.reserve(64);
+
+        total_order.reserve(n);
+    }
+};
+
+unsigned gps_deg(const unsigned* __restrict ptr, unsigned v) {
+    return ptr[v + 1] - ptr[v];
+}
+
+// BFS from `root`, filling `level[]` (which must be all -1 for reached vertices
+// beforehand; caller's touched-list reset handles this). Records touched
+// vertices. Returns (depth, width) computed inline via level-wave traversal.
+std::pair<int, unsigned> gps_bfs(
+    unsigned root,
+    const unsigned* __restrict ptr,
+    const unsigned* __restrict ind,
+    int* __restrict level,
+    unsigned* __restrict bfs_q,
+    std::vector<unsigned>& touched)
+{
+    unsigned qs = 0, qe = 0;
+    level[root] = 1;
+    touched.push_back(root);
+    bfs_q[qe++] = root;
+    int depth = 1;
+    unsigned width = 1;
+    while (qs < qe) {
+        const unsigned level_end = qe;
+        const unsigned cur_width = level_end - qs;
+        if (cur_width > width) width = cur_width;
+        const int cur_lvl = level[bfs_q[qs]];
+        if (cur_lvl > depth) depth = cur_lvl;
+        while (qs < level_end) {
+            const unsigned u = bfs_q[qs++];
+            for (unsigned p = ptr[u]; p < ptr[u + 1]; ++p) {
+                const unsigned v = ind[p];
+                if (level[v] == -1) {
+                    level[v] = cur_lvl + 1;
+                    touched.push_back(v);
+                    bfs_q[qe++] = v;
+                }
+            }
+        }
+    }
+    return {depth, width};
+}
+
+// Reset a level array to -1 at every touched entry, and clear the touched list.
+void gps_reset_level(int* level, std::vector<unsigned>& touched) {
+    for (unsigned v : touched) level[v] = -1;
+    touched.clear();
+}
+
+// Sort a candidate list by (degree asc, id asc). V1's `by_deg`.
+void gps_sort_by_deg(std::vector<unsigned>& xs,
+                                   const unsigned* __restrict ptr) {
+    std::ranges::sort(xs.begin(), xs.end(), [ptr](unsigned const a, unsigned const b) {
+        const unsigned da = gps_deg(ptr, a);
+        const unsigned db = gps_deg(ptr, b);
+        if (da != db) return da < db;
+        return a < b;
+    });
+}
+
+} // namespace
+
+
+void GPSOrdering::orderingFunction() {
+    if (rowIPermutation || colIPermutation) return;
+
+    const unsigned nr = getMatrix().getRowCount();
+    const unsigned nc = getMatrix().getColCount();
+    const unsigned* __restrict ptr = getMatrix().getPtr();
+    const unsigned* __restrict ind = getMatrix().getInd();
+
+    if (nr == 0) {
+        rowIPermutation = new vType[0];
+        colIPermutation = new vType[nc];
+        for (unsigned j = 0; j < nc; ++j) colIPermutation[j] = static_cast<vType>(j);
+        return;
+    }
+
+    GPSScratch sc;
+    sc.resize(nr);
+
+    // Max-degree across the whole graph: bucket-count size for the per-level
+    // counting sort below (replaces the comparison sort in Alg III pre-sort).
+    unsigned max_deg = 0;
+    for (unsigned v = 0; v < nr; ++v) {
+        const unsigned d = ptr[v + 1] - ptr[v];
+        if (d > max_deg) max_deg = d;
+    }
+    sc.deg_count.assign(max_deg + 2, 0);
+
+    // ------------------------------------------------------------------
+    // Outer CC decomposition: label every vertex with its component id via
+    // BFS from each unassigned seed in ascending id. Then build comp_verts
+    // sorted by ascending id within each component.
+    // ------------------------------------------------------------------
+    unsigned num_comps = 0;
+    for (unsigned s = 0; s < nr; ++s) {
+        if (sc.comp_id[s] != UINT_MAX) continue;
+        unsigned qs = 0, qe = 0;
+        sc.bfs_q[qe++] = s;
+        sc.comp_id[s] = num_comps;
+        while (qs < qe) {
+            const unsigned u = sc.bfs_q[qs++];
+            for (unsigned p = ptr[u]; p < ptr[u + 1]; ++p) {
+                const unsigned v = ind[p];
+                if (sc.comp_id[v] == UINT_MAX) {
+                    sc.comp_id[v] = num_comps;
+                    sc.bfs_q[qe++] = v;
+                }
+            }
+        }
+        ++num_comps;
+    }
+
+    sc.comp_start.assign(num_comps + 1, 0);
+    for (unsigned v = 0; v < nr; ++v) sc.comp_start[sc.comp_id[v] + 1]++;
+    for (unsigned c = 1; c <= num_comps; ++c) sc.comp_start[c] += sc.comp_start[c - 1];
+
+    sc.outer_cursor.assign(sc.comp_start.begin(), sc.comp_start.end());
+    for (unsigned v = 0; v < nr; ++v) {
+        const unsigned cid = sc.comp_id[v];
+        sc.comp_verts[sc.outer_cursor[cid]++] = v;
+    }
+
+    // ------------------------------------------------------------------
+    // Process each component in ascending-seed-id order (matches V1's
+    // for-s-in-0..nr outer loop visit order).
+    // ------------------------------------------------------------------
+    for (unsigned cid = 0; cid < num_comps; ++cid) {
+        const unsigned comp_begin = sc.comp_start[cid];
+        const unsigned comp_end   = sc.comp_start[cid + 1];
+        const unsigned n_comp     = comp_end - comp_begin;
+
+        // Isolated / singleton component -> append seed directly (V1 fast path).
+        if (n_comp == 1) {
+            sc.total_order.push_back(sc.comp_verts[comp_begin]);
+            continue;
+        }
+
+        // --------------------------------------------------------------
+        // Algorithm I: pseudo-diameter endpoints.
+        // --------------------------------------------------------------
+
+        // A. v := min-degree vertex in component (iterated in ascending id;
+        unsigned v_cur = sc.comp_verts[comp_begin];
+        unsigned v_deg = gps_deg(ptr, v_cur);
+        for (unsigned i = comp_begin + 1; i < comp_end; ++i) {
+            const unsigned c = sc.comp_verts[i];
+            const unsigned d = gps_deg(ptr, c);
+            if (d < v_deg) { v_deg = d; v_cur = c; }
+        }
+
+        // B. Build Lv.
+        auto Lv_dw = gps_bfs(v_cur, ptr, ind,
+                             sc.lv_level.data(), sc.bfs_q.data(), sc.touched_lv);
+        int      Lv_depth = Lv_dw.first;
+        unsigned Lv_width = Lv_dw.second;
+
+        // C/D fused: iterate sorted S once tracking (min_width, best_u). If any
+        // s improves depth, promote and restart outer. Otherwise one final BFS
+        // from best_u materializes Lu.
+        unsigned u_best = v_cur;
+        int      Lu_depth = Lv_depth;
+        unsigned Lu_width = Lv_width;
+        while (true) {
+            // Build S from touched_lv, filtered to last level.
+            sc.lastLevel.clear();
+            for (unsigned w : sc.touched_lv) {
+                if (sc.lv_level[w] == Lv_depth) sc.lastLevel.push_back(w);
+            }
+            gps_sort_by_deg(sc.lastLevel, ptr);
+
+            unsigned best_u_local = sc.lastLevel.empty() ? v_cur : sc.lastLevel[0];
+            unsigned best_w_local = UINT_MAX;
+            int      best_d_local = Lv_depth;
+            bool progressed = false;
+            for (unsigned s : sc.lastLevel) {
+                auto dw = gps_bfs(s, ptr, ind,
+                                  sc.tmp_level.data(), sc.bfs_q.data(),
+                                  sc.touched_tmp);
+                const int      s_depth = dw.first;
+                const unsigned s_width = dw.second;
+                if (s_depth > Lv_depth) {
+                    // Promote s. Discard any lu_level data; next while-iter rebuilds.
+                    gps_reset_level(sc.lv_level.data(), sc.touched_lv);
+                    sc.lv_level.swap(sc.tmp_level);
+                    sc.touched_lv.swap(sc.touched_tmp);
+                    gps_reset_level(sc.lu_level.data(), sc.touched_lu);
+                    v_cur    = s;
+                    Lv_depth = s_depth;
+                    Lv_width = s_width;
+                    progressed = true;
+                    break;
+                }
+                if (s_width < best_w_local) {
+                    // Preserve best candidate's BFS in lu_level (swap with tmp,
+                    // resetting the prior best). Eliminates a separate final
+                    // Lu BFS after the candidate loop.
+                    gps_reset_level(sc.lu_level.data(), sc.touched_lu);
+                    sc.lu_level.swap(sc.tmp_level);
+                    sc.touched_lu.swap(sc.touched_tmp);
+                    best_w_local = s_width;
+                    best_d_local = s_depth;
+                    best_u_local = s;
+                } else {
+                    gps_reset_level(sc.tmp_level.data(), sc.touched_tmp);
+                }
+            }
+            if (!progressed) {
+                u_best = best_u_local;
+                if (sc.touched_lu.empty()) {
+                    // Empty lastLevel fallback: materialize Lu from u_best.
+                    auto dw = gps_bfs(u_best, ptr, ind,
+                                      sc.lu_level.data(), sc.bfs_q.data(),
+                                      sc.touched_lu);
+                    Lu_depth = dw.first;
+                    Lu_width = dw.second;
+                } else {
+                    Lu_depth = best_d_local;
+                    Lu_width = best_w_local;
+                }
+                break;
+            }
+        }
+
+        const unsigned u_vert = u_best;
+        const unsigned v_vert = v_cur;
+
+        // --------------------------------------------------------------
+        // Algorithm II: combine Lv and Lu into a single level structure N.
+        // --------------------------------------------------------------
+        const int k_total = std::max(Lv_depth, Lu_depth);
+
+        // 1. i_of(w) = lv_level[w]; j_of(w) = k+1 - lu_level[w].
+        sc.touched_ij.clear();
+        // Fused steps 1-3: build i_of/j_of/touched_ij, place diagonals, mark
+        // rem in a single pass over comp_verts (was three sequential passes).
+        sc.touched_final.clear();
+        sc.counts_touched.clear();
+        for (unsigned i = comp_begin; i < comp_end; ++i) {
+            const unsigned w = sc.comp_verts[i];
+            const int iv = sc.lv_level[w];
+            const int ju = sc.lu_level[w];
+            if (iv > 0 && ju > 0) {
+                const int j_val = k_total + 1 - ju;
+                sc.i_of[w] = iv;
+                sc.j_of[w] = j_val;
+                sc.touched_ij.push_back(w);
+                if (iv == j_val) {
+                    sc.placed[w] = 1;
+                    sc.final_level[w] = iv;
+                    sc.touched_final.push_back(w);
+                    if (sc.counts[iv] == 0) sc.counts_touched.push_back(static_cast<unsigned>(iv));
+                    sc.counts[iv]++;
+                } else {
+                    sc.rem[w] = 1;
+                }
+            }
+        }
+
+        // 4. Inner CC over rem. Seed order: ascending vertex id within component,
+        // which makes cc_seeds[k] equal V1's per-subcomponent first vertex in
+        // BFS order (seed == lowest-id vertex in the subcomponent).
+        sc.touched_cc.clear();
+        sc.cc_verts.clear();
+        sc.cc_start.clear();
+        sc.cc_seeds.clear();
+        sc.cc_order.clear();
+        sc.cc_start.push_back(0);
+
+        for (unsigned i = comp_begin; i < comp_end; ++i) {
+            const unsigned seed = sc.comp_verts[i];
+            if (!sc.rem[seed] || sc.cc_mark[seed] != UINT_MAX) continue;
+
+            const auto sub_id = static_cast<unsigned>(sc.cc_seeds.size());
+            unsigned qs = 0, qe = 0;
+            sc.bfs_q[qe++] = seed;
+            sc.cc_mark[seed] = sub_id;
+            sc.touched_cc.push_back(seed);
+            sc.cc_verts.push_back(seed);
+            while (qs < qe) {
+                const unsigned u = sc.bfs_q[qs++];
+                for (unsigned p = ptr[u]; p < ptr[u + 1]; ++p) {
+                    const unsigned w = ind[p];
+                    if (sc.rem[w] && sc.cc_mark[w] == UINT_MAX) {
+                        sc.cc_mark[w] = sub_id;
+                        sc.touched_cc.push_back(w);
+                        sc.bfs_q[qe++] = w;
+                        sc.cc_verts.push_back(w);
+                    }
+                }
+            }
+            sc.cc_seeds.push_back(seed);
+            sc.cc_start.push_back(static_cast<unsigned>(sc.cc_verts.size()));
+        }
+        const auto num_sub = static_cast<unsigned>(sc.cc_seeds.size());
+
+        // 5. Sort subcomponents by (size desc, seed asc).
+        sc.cc_order.resize(num_sub);
+        for (unsigned i = 0; i < num_sub; ++i) sc.cc_order[i] = i;
+        std::ranges::sort(sc.cc_order.begin(), sc.cc_order.end(),
+            [&](unsigned a, unsigned b) {
+                const unsigned sa = sc.cc_start[a + 1] - sc.cc_start[a];
+                const unsigned sb = sc.cc_start[b + 1] - sc.cc_start[b];
+                if (sa != sb) return sa > sb;
+                return sc.cc_seeds[a] < sc.cc_seeds[b];
+            });
+
+        // 6. For each subcomponent, compute H/L, decide FIRST vs SECOND, assign
+        // final_level[w], update counts[r]. Record firstChoice from the first
+        // processed subcomponent (matches V1).
+        bool firstChoiceFirst = true;
+        bool first_choice_set = false;
+
+        for (unsigned idx : sc.cc_order) {
+            const unsigned start = sc.cc_start[idx];
+            const unsigned end   = sc.cc_start[idx + 1];
+
+            // Populate H[r], L[r] for this subcomponent.
+            for (unsigned i = start; i < end; ++i) {
+                const unsigned w = sc.cc_verts[i];
+                sc.Hbuf[sc.i_of[w]]++;
+                sc.Lbuf[sc.j_of[w]]++;
+            }
+
+            // V1 computes max over ALL r in 1..k_total (no "H[r]>0" guard, despite
+            // the paper's description). Preserve exactly.
+            int h0 = 0, l0 = 0;
+            for (int r = 1; r <= k_total; ++r) {
+                const int vh = sc.counts[r] + sc.Hbuf[r];
+                const int vl = sc.counts[r] + sc.Lbuf[r];
+                if (vh > h0) h0 = vh;
+                if (vl > l0) l0 = vl;
+            }
+
+            bool choose_first;
+            if (h0 < l0)      choose_first = true;
+            else if (l0 < h0) choose_first = false;
+            else {
+                // Tie on min-max: break by Lv vs Lu width. Tie-of-ties -> FIRST.
+                if (Lv_width < Lu_width)      choose_first = true;
+                else if (Lu_width < Lv_width) choose_first = false;
+                else                           choose_first = true;
+            }
+
+            if (!first_choice_set) {
+                firstChoiceFirst = choose_first;
+                first_choice_set = true;
+            }
+
+            // Assign final_level + bump counts.
+            if (choose_first) {
+                for (unsigned i = start; i < end; ++i) {
+                    const unsigned w = sc.cc_verts[i];
+                    const int r = sc.i_of[w];
+                    sc.final_level[w] = r;
+                    sc.touched_final.push_back(w);
+                    if (sc.counts[r] == 0) sc.counts_touched.push_back(static_cast<unsigned>(r));
+                    sc.counts[r]++;
+                }
+            } else {
+                for (unsigned i = start; i < end; ++i) {
+                    const unsigned w = sc.cc_verts[i];
+                    const int r = sc.j_of[w];
+                    sc.final_level[w] = r;
+                    sc.touched_final.push_back(w);
+                    if (sc.counts[r] == 0) sc.counts_touched.push_back(static_cast<unsigned>(r));
+                    sc.counts[r]++;
+                }
+            }
+
+            // Zero H, L for next subcomponent using this subcomponent's vertex
+            // list (idempotent: setting to 0 is safe even for repeated r).
+            for (unsigned i = start; i < end; ++i) {
+                const unsigned w = sc.cc_verts[i];
+                sc.Hbuf[sc.i_of[w]] = 0;
+                sc.Lbuf[sc.j_of[w]] = 0;
+            }
+        }
+
+        // --------------------------------------------------------------
+        // Algorithm III: numbering.
+        // --------------------------------------------------------------
+
+        // A. Swap u/v and reverse level indices if deg(u) < deg(v).
+        unsigned u_eff = u_vert, v_eff = v_vert;
+        bool swapped = false;
+        if (gps_deg(ptr, u_eff) < gps_deg(ptr, v_eff)) {
+            std::swap(u_eff, v_eff);
+            swapped = true;
+
+            // Flip level indices in-place for every placed vertex.
+            for (unsigned w : sc.touched_final) {
+                sc.final_level[w] = k_total + 1 - sc.final_level[w];
+            }
+
+            // Rebuild counts from scratch (index r becomes k+1-r).
+            for (unsigned r : sc.counts_touched) sc.counts[r] = 0;
+            sc.counts_touched.clear();
+            for (unsigned w : sc.touched_final) {
+                const int r = sc.final_level[w];
+                if (sc.counts[r] == 0) sc.counts_touched.push_back(static_cast<unsigned>(r));
+                sc.counts[r]++;
+            }
+        }
+
+        // Build N_off + N_flat from final_level via counting sort.
+        sc.N_off.assign(static_cast<size_t>(k_total + 2), 0);
+        for (unsigned r : sc.counts_touched) sc.N_off[r] = static_cast<unsigned>(sc.counts[r]);
+
+        unsigned acc = 0;
+        for (int r = 1; r <= k_total; ++r) {
+            const unsigned sz = sc.N_off[r];
+            sc.N_off[r] = acc;
+            acc += sz;
+        }
+        sc.N_off[k_total + 1] = acc;
+
+        sc.N_cursor.assign(sc.N_off.begin(), sc.N_off.end());
+        for (unsigned i = comp_begin; i < comp_end; ++i) {
+            const unsigned w = sc.comp_verts[i];
+            const int r = sc.final_level[w];
+            if (r >= 1 && r <= k_total) {
+                sc.N_flat[sc.N_cursor[r]++] = w;
+            }
+        }
+
+        // Pre-sort each level slice of N_flat by (deg asc, id asc) for the
+        // cursor-based leftover pickup. Counting sort by degree: O(L + maxDeg)
+        // per level instead of O(L log L) comparison sort. Within a degree
+        // bucket the original id-ascending order (inherited from comp_verts)
+        // is preserved by iterating the slice in scatter order.
+        for (int r = 1; r <= k_total; ++r) {
+            const unsigned beg = sc.N_off[r];
+            const unsigned end = sc.N_off[r + 1];
+            const unsigned L = end - beg;
+            if (L < 2) continue;
+
+            // Count phase + track unique degrees seen this level for cheap reset.
+            unsigned min_d = UINT_MAX, max_d = 0;
+            for (unsigned i = beg; i < end; ++i) {
+                const unsigned w = sc.N_flat[i];
+                const unsigned d = ptr[w + 1] - ptr[w];
+                sc.deg_count[d]++;
+                if (d < min_d) min_d = d;
+                if (d > max_d) max_d = d;
+            }
+            // Prefix sum across the active degree range.
+            unsigned acc = 0;
+            for (unsigned d = min_d; d <= max_d; ++d) {
+                const unsigned cnt = sc.deg_count[d];
+                sc.deg_count[d] = acc;
+                acc += cnt;
+            }
+            // Scatter into sort_scratch.
+            sc.sort_scratch.resize(L);
+            for (unsigned i = beg; i < end; ++i) {
+                const unsigned w = sc.N_flat[i];
+                const unsigned d = ptr[w + 1] - ptr[w];
+                sc.sort_scratch[sc.deg_count[d]++] = w;
+            }
+            // Copy back + clear touched degree counts.
+            for (unsigned i = 0; i < L; ++i) sc.N_flat[beg + i] = sc.sort_scratch[i];
+            for (unsigned d = min_d; d <= max_d; ++d) sc.deg_count[d] = 0;
+        }
+        // Re-purpose N_cursor: leftover-pickup cursor per level (advances past labeled).
+        sc.N_cursor.assign(sc.N_off.begin(), sc.N_off.end());
+
+        // B. Number level N_1.
+        sc.order.clear();
+        sc.touched_labeled.clear();
+        sc.level_start_in_order.assign(static_cast<size_t>(k_total + 2), 0);
+        sc.level_start_in_order[1] = 0;
+
+        //  B.1 Seed with v_eff if it lives in level 1 (V1: `if level_of[v]==1`).
+        if (sc.final_level[v_eff] == 1) {
+            sc.order.push_back(v_eff);
+            sc.labeled[v_eff] = 1;
+            sc.touched_labeled.push_back(v_eff);
+        }
+
+        //  B.2 + B.3: forward-walk intra-level-1 expansion + leftover pickup.
+        //  V1's semantics for level 1 are full B.2 iteration (every level-1
+        //  vertex that gains unnumbered level-1 neighbors gets expanded)
+        //  followed by leftover seed and loop.
+        size_t scan = 0;
+        while (true) {
+            while (scan < sc.order.size()) {
+                const unsigned w = sc.order[scan++];
+                if (sc.final_level[w] != 1) continue;
+                sc.cand.clear();
+                for (unsigned p = ptr[w]; p < ptr[w + 1]; ++p) {
+                    const unsigned x = ind[p];
+                    if (sc.final_level[x] == 1 && !sc.labeled[x]) sc.cand.push_back(x);
+                }
+                if (sc.cand.empty()) continue;
+                gps_sort_by_deg(sc.cand, ptr);
+                for (unsigned x : sc.cand) {
+                    sc.labeled[x] = 1;
+                    sc.touched_labeled.push_back(x);
+                    sc.order.push_back(x);
+                }
+            }
+            //  Leftover pickup: first unlabeled in pre-sorted (deg,id) N_flat[1].
+            unsigned& cur1 = sc.N_cursor[1];
+            const unsigned end1 = sc.N_off[2];
+            while (cur1 < end1 && sc.labeled[sc.N_flat[cur1]]) ++cur1;
+            if (cur1 >= end1) break;
+            const unsigned lo_best = sc.N_flat[cur1++];
+            sc.labeled[lo_best] = 1;
+            sc.touched_labeled.push_back(lo_best);
+            sc.order.push_back(lo_best);
+            // Re-enter forward walk; scan continues from where it was, which
+            // is now pointing at (or just past) the just-appended leftover.
+        }
+        sc.level_start_in_order[2] = static_cast<unsigned>(sc.order.size());
+
+        // C. Number levels N_2 .. N_k.
+        for (int i = 2; i <= k_total; ++i) {
+            const unsigned li_m1_start = sc.level_start_in_order[i - 1];
+            const unsigned li_m1_end   = sc.level_start_in_order[i];
+
+            // C.1 Single forward walk across level-(i-1) parents in `order`.
+            //     The natural iteration order gives V1's "lowest-numbered
+            //     parent with unnumbered level-i neighbors".
+            for (unsigned si = li_m1_start; si < li_m1_end; ++si) {
+                const unsigned parent = sc.order[si];
+                sc.cand.clear();
+                for (unsigned p = ptr[parent]; p < ptr[parent + 1]; ++p) {
+                    const unsigned x = ind[p];
+                    if (sc.final_level[x] == i && !sc.labeled[x]) sc.cand.push_back(x);
+                }
+                if (sc.cand.empty()) continue;
+                gps_sort_by_deg(sc.cand, ptr);
+                for (unsigned x : sc.cand) {
+                    sc.labeled[x] = 1;
+                    sc.touched_labeled.push_back(x);
+                    sc.order.push_back(x);
+                }
+            }
+
+            // C.2 Leftover pickup. NOTE: V1 deliberately does NOT perform the
+            //     full B.2 intra-level iteration for level i >= 2 -- only a
+            //     seed + one-hop expansion. Preserve that quirk exactly.
+            while (true) {
+                unsigned& curi = sc.N_cursor[i];
+                const unsigned endi = sc.N_off[i + 1];
+                while (curi < endi && sc.labeled[sc.N_flat[curi]]) ++curi;
+                if (curi >= endi) break;
+                const unsigned lo_best = sc.N_flat[curi++];
+                sc.labeled[lo_best] = 1;
+                sc.touched_labeled.push_back(lo_best);
+                sc.order.push_back(lo_best);
+
+                // One-hop expansion from lo_best within level i.
+                sc.cand.clear();
+                for (unsigned p = ptr[lo_best]; p < ptr[lo_best + 1]; ++p) {
+                    const unsigned x = ind[p];
+                    if (sc.final_level[x] == i && !sc.labeled[x]) sc.cand.push_back(x);
+                }
+                if (!sc.cand.empty()) {
+                    gps_sort_by_deg(sc.cand, ptr);
+                    for (unsigned x : sc.cand) {
+                        sc.labeled[x] = 1;
+                        sc.touched_labeled.push_back(x);
+                        sc.order.push_back(x);
+                    }
+                }
+            }
+            sc.level_start_in_order[i + 1] = static_cast<unsigned>(sc.order.size());
+        }
+
+        // D. GPS reversal rule.
+        const bool needReverse =
+            ( swapped && !firstChoiceFirst) ||
+            (!swapped &&  firstChoiceFirst);
+        if (needReverse) {
+            std::ranges::reverse(sc.order.begin(), sc.order.end());
+        }
+
+        // Append this component's order into the global total.
+        for (unsigned w : sc.order) sc.total_order.push_back(w);
+
+        // --------------------------------------------------------------
+        // Per-component scratch reset (proportional to component size).
+        // --------------------------------------------------------------
+        gps_reset_level(sc.lv_level.data(),  sc.touched_lv);
+        gps_reset_level(sc.lu_level.data(),  sc.touched_lu);
+        gps_reset_level(sc.tmp_level.data(), sc.touched_tmp);
+
+        for (unsigned w : sc.touched_ij) {
+            sc.i_of[w]   = -1;
+            sc.j_of[w]   = -1;
+            sc.placed[w] = 0;
+            sc.rem[w]    = 0;
+        }
+        sc.touched_ij.clear();
+
+        for (unsigned r : sc.counts_touched) sc.counts[r] = 0;
+        sc.counts_touched.clear();
+
+        for (unsigned w : sc.touched_final) sc.final_level[w] = -1;
+        sc.touched_final.clear();
+
+        for (unsigned w : sc.touched_labeled) sc.labeled[w] = 0;
+        sc.touched_labeled.clear();
+
+        for (unsigned w : sc.touched_cc) sc.cc_mark[w] = UINT_MAX;
+        sc.touched_cc.clear();
+    }
+
+    // V1-compatible safety: append any vertex never written to total_order
+    // (should not occur with correct CC, but preserve behavior).
+    if (sc.total_order.size() != nr) {
+        std::vector<char> seen(nr, 0);
+        for (unsigned w : sc.total_order) seen[w] = 1;
+        for (unsigned v = 0; v < nr; ++v) {
+            if (!seen[v]) sc.total_order.push_back(v);
+        }
+    }
+    assert(sc.total_order.size() == nr);
+
+    // Write row permutation: newPos -> vertex, so rowIPermutation[v] = newPos.
+    rowIPermutation = new vType[nr];
+    for (unsigned newPos = 0; newPos < nr; ++newPos) {
+        rowIPermutation[sc.total_order[newPos]] = static_cast<vType>(newPos);
+    }
+
+    // Column permutation: mirror rows when square, else identity.
+    colIPermutation = new vType[nc];
+    if (nr == nc) {
+        for (unsigned v = 0; v < nc; ++v) colIPermutation[v] = rowIPermutation[v];
+    } else {
+        for (unsigned j = 0; j < nc; ++j) colIPermutation[j] = static_cast<vType>(j);
+    }
+}

--- a/src/Matrix/Orderings/RBFS-GLOrderingV2.cpp
+++ b/src/Matrix/Orderings/RBFS-GLOrderingV2.cpp
@@ -1,0 +1,142 @@
+//
+// RBFS-GLOrderingV2.cpp — optimized RBFS-GL ordering
+// Key changes vs V1:
+//   1. level[] allocated once; per-component reset via touched-list (O(comp) not O(n))
+//   2. Min-degree vertex chosen as BFS root per component (better ordering quality)
+//
+#include "RBFS-GLOrdering.h"
+#include <queue>
+using std::vector;
+
+namespace {
+
+struct RBFSGLNode {
+    int      level;
+    unsigned degree;
+    unsigned id;
+};
+
+struct RBFSGLNodeCompare {
+    bool operator()(const RBFSGLNode& a, const RBFSGLNode& b) const {
+        if (a.level  != b.level)  return a.level  > b.level;
+        if (a.degree != b.degree) return a.degree > b.degree;
+        return a.id > b.id;
+    }
+};
+
+struct RBFSGLScratch {
+    vector<int>      level;    // size n, all -1; reset via touched_level
+    vector<unsigned> touched_level;
+
+    void resize(unsigned n) {
+        level.assign(n, -1);
+        touched_level.reserve(n);
+    }
+
+    void reset() {
+        for (unsigned v : touched_level) level[v] = -1;
+        touched_level.clear();
+    }
+};
+
+// BFS from root using Gibbs-Lewis priority queue.
+// Uses pre-allocated scratch for the level array.
+static void bfsGL_impl(
+    unsigned root,
+    const vType* ptr, const vType* ind,
+    const vector<unsigned>& degree,
+    vector<char>& assigned,
+    vector<unsigned>& visitOrder,
+    RBFSGLScratch& sc
+) {
+    sc.reset();
+
+    std::priority_queue<RBFSGLNode, vector<RBFSGLNode>, RBFSGLNodeCompare> pq;
+
+    sc.level[root] = 0;
+    sc.touched_level.push_back(root);
+    assigned[root]  = 1;
+    pq.push(RBFSGLNode{0, degree[root], root});
+
+    while (!pq.empty()) {
+        const RBFSGLNode cur = pq.top();
+        pq.pop();
+
+        const unsigned v  = cur.id;
+        visitOrder.push_back(v);
+        const int lv = cur.level;
+
+        for (vType kk = ptr[v]; kk < ptr[v + 1]; ++kk) {
+            const unsigned u = static_cast<unsigned>(ind[kk]);
+            if (assigned[u]) continue;
+
+            assigned[u]      = 1;
+            sc.level[u]      = lv + 1;
+            sc.touched_level.push_back(u);
+            pq.push(RBFSGLNode{lv + 1, degree[u], u});
+        }
+    }
+}
+
+} // namespace
+
+void RBFSGLOrdering::orderingFunction() {
+    const SparseMatrix& A = this->getMatrix();
+    const unsigned n = A.getRowCount();
+
+    const vType* ptr = A.getPtr();
+    const vType* ind = A.getInd();
+
+    rowIPermutation = new vType[n];
+    colIPermutation = new vType[n];
+
+    vector<unsigned> degree(n);
+    for (unsigned v = 0; v < n; ++v)
+        degree[v] = static_cast<unsigned>(ptr[v + 1] - ptr[v]);
+
+    vector<char>     assigned(n, 0);
+    vector<unsigned> visitOrder;
+    visitOrder.reserve(n);
+
+    RBFSGLScratch sc;
+    sc.resize(n);
+
+    for (unsigned v = 0; v < n; ++v) {
+        if (assigned[v]) continue;
+
+        // Pick root as the minimum-degree neighbor of v (single-hop heuristic).
+        // Guaranteed to be in the same component; O(degree[v]) cost per component.
+        // The GL priority queue already orders by degree within levels, so this
+        // mainly improves the starting point of the traversal.
+        unsigned root   = v;
+        unsigned minDeg = degree[v];
+        for (vType kk = ptr[v]; kk < ptr[v + 1]; ++kk) {
+            const unsigned u = static_cast<unsigned>(ind[kk]);
+            if (degree[u] < minDeg) { minDeg = degree[u]; root = u; }
+        }
+
+        bfsGL_impl(root, ptr, ind, degree, assigned, visitOrder, sc);
+    }
+
+    // RBFS: reverse the visit order
+    for (unsigned newPos = 0; newPos < n; ++newPos) {
+        const unsigned v = visitOrder[n - 1 - newPos];
+        rowIPermutation[v] = static_cast<vType>(newPos);
+        colIPermutation[v] = static_cast<vType>(newPos);
+    }
+}
+
+// Keep V1's bfsGL defined (declared in header) — delegates to the new impl.
+void RBFSGLOrdering::bfsGL(unsigned root,
+                            const vector<unsigned>& degree,
+                            vector<char>& assigned,
+                            vector<unsigned>& visitOrder)
+{
+    const SparseMatrix& A = this->getMatrix();
+    const vType* ptr = A.getPtr();
+    const vType* ind = A.getInd();
+
+    RBFSGLScratch sc;
+    sc.resize(A.getRowCount());
+    bfsGL_impl(root, ptr, ind, degree, assigned, visitOrder, sc);
+}

--- a/src/Matrix/Orderings/Sloan-MGPSOrderingV2.cpp
+++ b/src/Matrix/Orderings/Sloan-MGPSOrderingV2.cpp
@@ -1,0 +1,297 @@
+//
+// Sloan-MGPSOrderingV2.cpp — optimized Sloan-MGPS ordering
+// Key changes vs V1:
+//   1. Inherits heap-based Numbering from SloanOrderingV2 (O(n^2) -> O((n+m) log n))
+//   2. Touched-list BFS resets (O(n) per call -> O(component))
+//   3. Flat vector BFS queue
+//   4. isNeighborOfAnyPicked uses flat bool array (O(1) lookup vs O(|picked|))
+//   5. Monotone seed cursor
+//
+#include "Sloan-MGPSOrdering.h"
+#include <algorithm>
+#include <limits>
+#include <vector>
+#include "SparseMatrix.h"
+
+// ── scratch + BFS helper (same pattern as SloanOrderingV2, duplicated per-TU) ─
+namespace {
+
+struct SloanScratch {
+    std::vector<int>                   level;
+    std::vector<unsigned>              touched_level;
+    std::vector<unsigned>              bfs_q;
+    std::vector<std::vector<unsigned>> byLevel;
+    std::vector<unsigned>              byLevel_touched;
+
+    void resize(unsigned n) {
+        level.assign(n, -1);
+        touched_level.reserve(n);
+        bfs_q.resize(n);
+    }
+
+    void reset_level() {
+        for (unsigned v : touched_level) level[v] = -1;
+        touched_level.clear();
+    }
+
+    void reset_byLevel() {
+        for (unsigned lv : byLevel_touched) byLevel[lv].clear();
+        byLevel_touched.clear();
+    }
+};
+
+static void bls_impl(
+    unsigned root,
+    const vType* ptr, const vType* ind, unsigned n,
+    SloanScratch& sc,
+    unsigned& out_depth, unsigned& out_width,
+    unsigned widthMin
+) {
+    sc.reset_level();
+    sc.reset_byLevel();
+    out_depth = 0;
+    out_width = 0;
+
+    sc.level[root] = 0;
+    sc.touched_level.push_back(root);
+
+    if (sc.byLevel.empty()) sc.byLevel.emplace_back();
+    sc.byLevel[0].push_back(root);
+    sc.byLevel_touched.push_back(0);
+    out_width = 1;
+
+    unsigned head = 0, tail = 0;
+    sc.bfs_q[tail++] = root;
+
+    while (head < tail) {
+        const unsigned v  = sc.bfs_q[head++];
+        const unsigned nL = static_cast<unsigned>(sc.level[v]) + 1;
+
+        for (vType k = ptr[v]; k < ptr[v + 1]; ++k) {
+            const unsigned u = static_cast<unsigned>(ind[k]);
+            if (u >= n || sc.level[u] != -1) continue;
+
+            sc.level[u] = static_cast<int>(nL);
+            sc.touched_level.push_back(u);
+
+            if (sc.byLevel.size() <= nL) sc.byLevel.resize(nL + 1);
+            if (sc.byLevel[nL].empty())  sc.byLevel_touched.push_back(nL);
+            sc.byLevel[nL].push_back(u);
+            sc.bfs_q[tail++] = u;
+
+            const unsigned sz = static_cast<unsigned>(sc.byLevel[nL].size());
+            if (sz > out_width) out_width = sz;
+            if (out_width > widthMin) {
+                out_depth = static_cast<unsigned>(sc.byLevel.size());
+                return;
+            }
+        }
+    }
+
+    out_depth = static_cast<unsigned>(sc.byLevel.size());
+    while (out_depth > 0 && sc.byLevel[out_depth - 1].empty()) --out_depth;
+}
+
+// MGPS endpoint search — limits to 5 non-adjacent candidates.
+// Uses a flat bool array (is_picked) for O(1) adjacency checks.
+static void find_endpoints_mgps_impl(
+    unsigned s,
+    const vType* ptr, const vType* ind, unsigned n,
+    const std::vector<unsigned>& degree,
+    SloanScratch& sc,
+    std::vector<bool>& is_picked,   // size n, all false on entry and exit
+    unsigned& sOut, unsigned& eOut
+) {
+    sOut = s; eOut = s;
+    if (n == 0) return;
+
+    std::vector<unsigned> Q_sorted;
+    std::vector<unsigned> Qpicked;
+    Qpicked.reserve(5);
+
+    while (true) {
+        unsigned depth_s, width_s;
+        bls_impl(s, ptr, ind, n, sc, depth_s, width_s,
+                 std::numeric_limits<unsigned>::max());
+
+        if (depth_s == 0) { sOut = s; eOut = s; return; }
+
+        const std::vector<unsigned>& last = sc.byLevel[depth_s - 1];
+        if (last.empty()) { sOut = s; eOut = s; return; }
+
+        // Sort last level by ascending degree, then pick up to 5 non-adjacent
+        Q_sorted = last;
+        std::sort(Q_sorted.begin(), Q_sorted.end(), [&](unsigned a, unsigned b) {
+            return degree[a] != degree[b] ? degree[a] < degree[b] : a < b;
+        });
+
+        Qpicked.clear();
+        for (unsigned v : Q_sorted) {
+            if (Qpicked.size() == 5) break;
+            // O(degree[v]) adjacency check using flat bool array
+            bool adjacent = false;
+            for (vType k = ptr[v]; k < ptr[v + 1]; ++k) {
+                if (is_picked[static_cast<unsigned>(ind[k])]) {
+                    adjacent = true; break;
+                }
+            }
+            if (adjacent) continue;
+            is_picked[v] = true;
+            Qpicked.push_back(v);
+        }
+        // Clean up is_picked (only the ≤5 entries we set)
+        for (unsigned v : Qpicked) is_picked[v] = false;
+
+        unsigned depth_Li = 0, width_Li = 0;
+        unsigned wMin    = std::numeric_limits<unsigned>::max();
+        const unsigned hMax = depth_s;
+        unsigned e       = s;
+        bool     restart = false;
+
+        for (unsigned i : Qpicked) {
+            bls_impl(i, ptr, ind, n, sc, depth_Li, width_Li, wMin);
+
+            if (depth_Li > hMax && width_Li < wMin) {
+                s = i; restart = true; break;
+            }
+            if (width_Li < wMin) { e = i; wMin = width_Li; }
+        }
+
+        if (restart) continue;
+
+        // MGPS: choose narrower structure as starting node
+        if (width_Li > width_s) {
+            sOut = e; eOut = s;
+        } else {
+            sOut = s; eOut = e;
+        }
+        return;
+    }
+}
+
+} // namespace
+
+// ── MGPSSloanOrdering class method implementations ───────────────────────────
+
+// buildLevelStructure: MGPS has its own static version (hides parent's).
+// V2 uses scratch internally, exposing the same external API.
+void MGPSSloanOrdering::buildLevelStructure(
+    unsigned root,
+    const vType* ptr, const vType* ind, unsigned n,
+    LevelStructure& out, unsigned widthMin
+) {
+    SloanScratch sc;
+    sc.resize(n);
+    unsigned depth, width;
+    bls_impl(root, ptr, ind, n, sc, depth, width, widthMin);
+
+    out.depth = depth;
+    out.width = width;
+    out.level.assign(n, -1);
+    for (unsigned v : sc.touched_level) out.level[v] = sc.level[v];
+    out.byLevel.assign(depth, {});
+    for (unsigned lv : sc.byLevel_touched)
+        if (lv < depth) out.byLevel[lv] = sc.byLevel[lv];
+}
+
+bool MGPSSloanOrdering::isNeighborOfAnyPicked(
+    unsigned v,
+    const vType* ptr, const vType* ind,
+    const std::vector<unsigned>& picked
+) {
+    // V1 fallback (only called externally if at all; hot path uses is_picked bool array)
+    for (vType k = ptr[v]; k < ptr[v + 1]; ++k) {
+        const unsigned u = static_cast<unsigned>(ind[k]);
+        for (unsigned t : picked) if (u == t) return true;
+    }
+    return false;
+}
+
+void MGPSSloanOrdering::findPseudoPeripheralEndpointsMGPS(
+    unsigned s,
+    const vType* ptr, const vType* ind, unsigned n,
+    const std::vector<unsigned>& degree,
+    unsigned& sOut, unsigned& eOut
+) {
+    SloanScratch sc;
+    sc.resize(n);
+    std::vector<bool> is_picked(n, false);
+    find_endpoints_mgps_impl(s, ptr, ind, n, degree, sc, is_picked, sOut, eOut);
+}
+
+void MGPSSloanOrdering::orderingFunction() {
+    const SparseMatrix& A = this->getMatrix();
+    const unsigned n = A.getRowCount();
+    if (n == 0) return;
+
+    const vType* ptr = A.getPtr();
+    const vType* ind = A.getInd();
+
+    rowIPermutation = new vType[n];
+    colIPermutation = new vType[n];
+
+    const unsigned UNLABELED = std::numeric_limits<unsigned>::max();
+
+    std::vector<unsigned> degree(n);
+    for (unsigned v = 0; v < n; ++v)
+        degree[v] = static_cast<unsigned>(ptr[v + 1] - ptr[v]);
+
+    std::vector<unsigned> globalLabels(n, UNLABELED);
+    unsigned globalLabel = 0;
+
+    SloanScratch sc;
+    sc.resize(n);
+    std::vector<bool> is_picked(n, false); // reused across components
+
+    std::vector<NodeInfo> info;
+    std::vector<unsigned> eligible;
+    std::vector<unsigned> localLabels;
+
+    unsigned seed_cursor = 0;
+
+    while (globalLabel < n) {
+        while (seed_cursor < n && globalLabels[seed_cursor] != UNLABELED)
+            ++seed_cursor;
+        if (seed_cursor >= n) break;
+        const unsigned seed = seed_cursor;
+
+        if (degree[seed] == 0) {
+            globalLabels[seed] = globalLabel++;
+            ++seed_cursor;
+            continue;
+        }
+
+        unsigned s = seed, e = seed;
+        find_endpoints_mgps_impl(seed, ptr, ind, n, degree, sc, is_picked, s, e);
+
+        // Build L(e) for initializeNodeInfo
+        unsigned depth_e, width_e;
+        bls_impl(e, ptr, ind, n, sc, depth_e, width_e,
+                 std::numeric_limits<unsigned>::max());
+
+        LevelStructure Le;
+        Le.depth = depth_e;
+        Le.width = width_e;
+        Le.level.assign(n, -1);
+        for (unsigned v : sc.touched_level) Le.level[v] = sc.level[v];
+
+        initializeNodeInfo(info, Le, n, degree, W1, W2);
+
+        // Numbering resolves to SloanOrderingV2's heap-based implementation
+        Numbering(s, ptr, ind, n, W1, info, eligible, localLabels);
+
+        unsigned labeledThisRun = 0;
+        for (unsigned v : sc.touched_level) {
+            if (localLabels[v] != UNLABELED && globalLabels[v] == UNLABELED) {
+                globalLabels[v] = globalLabel + localLabels[v];
+                ++labeledThisRun;
+            }
+        }
+        globalLabel += labeledThisRun;
+    }
+
+    for (unsigned v = 0; v < n; ++v) {
+        rowIPermutation[v] = static_cast<vType>(globalLabels[v]);
+        colIPermutation[v] = static_cast<vType>(globalLabels[v]);
+    }
+}

--- a/src/Matrix/Orderings/SloanOrderingV2.cpp
+++ b/src/Matrix/Orderings/SloanOrderingV2.cpp
@@ -1,0 +1,352 @@
+//
+// SloanOrderingV2.cpp — optimized Sloan ordering
+// Key changes vs V1:
+//   1. Lazy-deletion max-heap in Numbering (O(n^2) -> O((n+m) log n))
+//   2. Touched-list BFS resets in buildLevelStructure (O(n) per call -> O(component))
+//   3. Flat vector BFS queue instead of std::queue
+//   4. Monotone seed cursor in orderingFunction (O(n) total vs O(n) per component)
+//
+#include "SloanOrdering.h"
+#include <algorithm>
+#include <limits>
+#include <queue>
+#include <vector>
+#include "SparseMatrix.h"
+
+// ── scratch struct + BFS helper (anonymous, this TU only) ────────────────────
+namespace {
+
+struct SloanScratch {
+    std::vector<int>                   level;
+    std::vector<unsigned>              touched_level;
+    std::vector<unsigned>              bfs_q;
+    std::vector<std::vector<unsigned>> byLevel;
+    std::vector<unsigned>              byLevel_touched;
+
+    void resize(unsigned n) {
+        level.assign(n, -1);
+        touched_level.reserve(n);
+        bfs_q.resize(n);
+    }
+
+    void reset_level() {
+        for (unsigned v : touched_level) level[v] = -1;
+        touched_level.clear();
+    }
+
+    void reset_byLevel() {
+        for (unsigned lv : byLevel_touched) byLevel[lv].clear();
+        byLevel_touched.clear();
+    }
+};
+
+// BFS from root, filling sc.level / sc.byLevel.
+// Early-exits (with partial results) if width > widthMin.
+static void bls_impl(
+    unsigned root,
+    const vType* ptr, const vType* ind, unsigned n,
+    SloanScratch& sc,
+    unsigned& out_depth, unsigned& out_width,
+    unsigned widthMin
+) {
+    sc.reset_level();
+    sc.reset_byLevel();
+    out_depth = 0;
+    out_width = 0;
+
+    sc.level[root] = 0;
+    sc.touched_level.push_back(root);
+
+    if (sc.byLevel.empty()) sc.byLevel.emplace_back();
+    sc.byLevel[0].push_back(root);
+    sc.byLevel_touched.push_back(0);
+    out_width = 1;
+
+    unsigned head = 0, tail = 0;
+    sc.bfs_q[tail++] = root;
+
+    while (head < tail) {
+        const unsigned v  = sc.bfs_q[head++];
+        const unsigned nL = static_cast<unsigned>(sc.level[v]) + 1;
+
+        for (vType k = ptr[v]; k < ptr[v + 1]; ++k) {
+            const unsigned u = static_cast<unsigned>(ind[k]);
+            if (u >= n || sc.level[u] != -1) continue;
+
+            sc.level[u] = static_cast<int>(nL);
+            sc.touched_level.push_back(u);
+
+            if (sc.byLevel.size() <= nL) sc.byLevel.resize(nL + 1);
+            if (sc.byLevel[nL].empty())  sc.byLevel_touched.push_back(nL);
+            sc.byLevel[nL].push_back(u);
+            sc.bfs_q[tail++] = u;
+
+            const unsigned sz = static_cast<unsigned>(sc.byLevel[nL].size());
+            if (sz > out_width) out_width = sz;
+            if (out_width > widthMin) {
+                out_depth = static_cast<unsigned>(sc.byLevel.size());
+                return;
+            }
+        }
+    }
+
+    out_depth = static_cast<unsigned>(sc.byLevel.size());
+    while (out_depth > 0 && sc.byLevel[out_depth - 1].empty()) --out_depth;
+}
+
+// Pseudo-peripheral endpoint search, reusing a shared scratch for all BFS calls.
+static void find_endpoints_impl(
+    unsigned s,
+    const vType* ptr, const vType* ind, unsigned n,
+    const std::vector<unsigned>& degree,
+    SloanScratch& sc,
+    unsigned& sOut, unsigned& eOut
+) {
+    sOut = s; eOut = s;
+    if (n == 0) return;
+
+    std::vector<unsigned> Q_cands;
+
+    while (true) {
+        unsigned depth_s, width_s;
+        bls_impl(s, ptr, ind, n, sc, depth_s, width_s,
+                 std::numeric_limits<unsigned>::max());
+
+        if (depth_s == 0) { sOut = s; eOut = s; return; }
+
+        const std::vector<unsigned>& last = sc.byLevel[depth_s - 1];
+        if (last.empty())  { sOut = s; eOut = s; return; }
+
+        Q_cands = last;
+        const size_t m = Q_cands.size();
+        std::sort(Q_cands.begin(), Q_cands.end(), [&](unsigned a, unsigned b) {
+            return degree[a] != degree[b] ? degree[a] < degree[b] : a < b;
+        });
+        Q_cands.resize((m + 2) / 2);
+
+        unsigned wMin  = std::numeric_limits<unsigned>::max();
+        const unsigned hMax = depth_s;
+        unsigned e     = s;
+        bool     restart = false;
+
+        for (unsigned i : Q_cands) {
+            unsigned depth_i, width_i;
+            bls_impl(i, ptr, ind, n, sc, depth_i, width_i, wMin);
+
+            if (depth_i > hMax && width_i < wMin) {
+                s = i; restart = true; break;
+            }
+            if (width_i < wMin) { e = i; wMin = width_i; }
+        }
+
+        if (restart) continue;
+        sOut = s; eOut = e;
+        return;
+    }
+}
+
+} // namespace
+
+// ── SloanOrdering class method implementations ───────────────────────────────
+
+void SloanOrdering::buildLevelStructure(
+    unsigned root,
+    const vType* ptr, const vType* ind, unsigned n,
+    LevelStructure& out, unsigned widthMin
+) {
+    SloanScratch sc;
+    sc.resize(n);
+    unsigned depth, width;
+    bls_impl(root, ptr, ind, n, sc, depth, width, widthMin);
+
+    out.depth = depth;
+    out.width = width;
+    out.level.assign(n, -1);
+    for (unsigned v : sc.touched_level) out.level[v] = sc.level[v];
+    out.byLevel.assign(depth, {});
+    for (unsigned lv : sc.byLevel_touched)
+        if (lv < depth) out.byLevel[lv] = sc.byLevel[lv];
+}
+
+void SloanOrdering::findPseudoPeripheralEndpoints(
+    unsigned s,
+    const vType* ptr, const vType* ind, unsigned n,
+    const std::vector<unsigned>& degree,
+    unsigned& sOut, unsigned& eOut
+) {
+    SloanScratch sc;
+    sc.resize(n);
+    find_endpoints_impl(s, ptr, ind, n, degree, sc, sOut, eOut);
+}
+
+void SloanOrdering::initializeNodeInfo(
+    std::vector<NodeInfo>& info,
+    const LevelStructure& Le,
+    unsigned n,
+    const std::vector<unsigned>& degree,
+    const int& W1, const int& W2
+) {
+    info.assign(n, NodeInfo{});
+    const std::vector<int>& dist = Le.level;
+
+    for (unsigned v = 0; v < n; ++v) {
+        NodeInfo& ni   = info[v];
+        ni.degree      = degree[v];
+        ni.currentDegree = ni.degree + 1;
+        ni.distToEnd   = dist[v];
+        ni.priority    = (ni.distToEnd < 0)
+            ? std::numeric_limits<int>::min()
+            : static_cast<int>(n - ni.currentDegree) * W1 + ni.distToEnd * W2;
+    }
+}
+
+void SloanOrdering::Numbering(
+    unsigned s,
+    const vType* ptr, const vType* ind, unsigned n,
+    int W1,
+    std::vector<NodeInfo>& info,
+    std::vector<unsigned>& /* eligible — unused in V2 */,
+    std::vector<unsigned>& labels
+) {
+    labels.assign(n, std::numeric_limits<unsigned>::max());
+
+    using Pair = std::pair<int, unsigned>;
+    std::priority_queue<Pair> heap;
+
+    info[s].status = Status::Preactive;
+    heap.push({info[s].priority, s});
+
+    unsigned nextLabel = 0;
+
+    while (!heap.empty()) {
+        const auto [p, i] = heap.top();
+        heap.pop();
+
+        if (info[i].status == Status::Postactive) continue;
+        if (p != info[i].priority)                continue; // stale entry
+
+        const bool wasPreactive = (info[i].status == Status::Preactive);
+
+        // Step 7: if i was Preactive, update all neighbors
+        if (wasPreactive) {
+            for (vType kk = ptr[i]; kk < ptr[i + 1]; ++kk) {
+                const unsigned j = static_cast<unsigned>(ind[kk]);
+                if (j >= n) continue;
+                info[j].priority += W1;
+                if (info[j].status == Status::Inactive) {
+                    info[j].status = Status::Preactive;
+                    heap.push({info[j].priority, j});
+                } else if (info[j].status != Status::Postactive) {
+                    heap.push({info[j].priority, j}); // lazy re-push for Active/Preactive
+                }
+            }
+        }
+
+        // Step 8: label i -> Postactive
+        labels[i]      = nextLabel++;
+        info[i].status = Status::Postactive;
+
+        // Step 9: promote each Preactive neighbor of i to Active
+        for (vType kk = ptr[i]; kk < ptr[i + 1]; ++kk) {
+            const unsigned j = static_cast<unsigned>(ind[kk]);
+            if (j >= n || info[j].status != Status::Preactive) continue;
+
+            info[j].priority += W1;
+            info[j].status    = Status::Active;
+            heap.push({info[j].priority, j});
+
+            for (vType kk2 = ptr[j]; kk2 < ptr[j + 1]; ++kk2) {
+                const unsigned k = static_cast<unsigned>(ind[kk2]);
+                if (k >= n) continue;
+                if (info[k].status == Status::Active ||
+                    info[k].status == Status::Preactive) {
+                    info[k].priority += W1;
+                    heap.push({info[k].priority, k});
+                } else if (info[k].status == Status::Inactive) {
+                    info[k].priority += W1;
+                    info[k].status    = Status::Preactive;
+                    heap.push({info[k].priority, k});
+                }
+            }
+        }
+    }
+}
+
+void SloanOrdering::orderingFunction() {
+    const SparseMatrix& A = this->getMatrix();
+    const unsigned n = A.getRowCount();
+    if (n == 0) return;
+
+    const vType* ptr = A.getPtr();
+    const vType* ind = A.getInd();
+
+    rowIPermutation = new vType[n];
+    colIPermutation = new vType[n];
+
+    const unsigned UNLABELED = std::numeric_limits<unsigned>::max();
+
+    std::vector<unsigned> degree(n);
+    for (unsigned v = 0; v < n; ++v)
+        degree[v] = static_cast<unsigned>(ptr[v + 1] - ptr[v]);
+
+    std::vector<unsigned> globalLabels(n, UNLABELED);
+    unsigned globalLabel = 0;
+
+    SloanScratch sc;
+    sc.resize(n);
+
+    // Reused across components to avoid repeated allocations
+    std::vector<NodeInfo> info;
+    std::vector<unsigned> eligible;
+    std::vector<unsigned> localLabels;
+
+    unsigned seed_cursor = 0; // monotone — O(n) total scan
+
+    while (globalLabel < n) {
+        while (seed_cursor < n && globalLabels[seed_cursor] != UNLABELED)
+            ++seed_cursor;
+        if (seed_cursor >= n) break;
+        const unsigned seed = seed_cursor;
+
+        if (degree[seed] == 0) {
+            globalLabels[seed] = globalLabel++;
+            ++seed_cursor;
+            continue;
+        }
+
+        // Find pseudo-peripheral endpoints using shared scratch
+        unsigned s = seed, e = seed;
+        find_endpoints_impl(seed, ptr, ind, n, degree, sc, s, e);
+
+        // Build L(e) — needed for initializeNodeInfo
+        unsigned depth_e, width_e;
+        bls_impl(e, ptr, ind, n, sc, depth_e, width_e,
+                 std::numeric_limits<unsigned>::max());
+
+        // Populate LevelStructure from scratch (O(n) for Le.level — once per component)
+        LevelStructure Le;
+        Le.depth = depth_e;
+        Le.width = width_e;
+        Le.level.assign(n, -1);
+        for (unsigned v : sc.touched_level) Le.level[v] = sc.level[v];
+
+        initializeNodeInfo(info, Le, n, degree, W1, W2);
+
+        Numbering(s, ptr, ind, n, W1, info, eligible, localLabels);
+
+        // Commit labels (iterate only component vertices via sc.touched_level)
+        unsigned labeledThisRun = 0;
+        for (unsigned v : sc.touched_level) {
+            if (localLabels[v] != UNLABELED && globalLabels[v] == UNLABELED) {
+                globalLabels[v] = globalLabel + localLabels[v];
+                ++labeledThisRun;
+            }
+        }
+        globalLabel += labeledThisRun;
+    }
+
+    for (unsigned v = 0; v < n; ++v) {
+        rowIPermutation[v] = static_cast<vType>(globalLabels[v]);
+        colIPermutation[v] = static_cast<vType>(globalLabels[v]);
+    }
+}

--- a/src/Matrix/Orderings/VNSBandOrderingV3+RCM.cpp
+++ b/src/Matrix/Orderings/VNSBandOrderingV3+RCM.cpp
@@ -1,0 +1,1185 @@
+// Created by grkmshn on 11/20/25.
+// V3+RCM: identical to VNSBandOrderingV3 but uses RCM as the initial labeling
+//         instead of the randomised BFS (initialVNSBandLabeling).
+
+#include "VNSBandOrdering.h"
+#include <vector>
+#include <random>
+#include <cstddef>
+#include <algorithm>
+#include <limits>
+#include <cmath>
+#include <chrono>
+#include <iostream>
+#include <iomanip>
+#include <numeric>
+#include <string>
+#include <omp.h>
+
+// ============================================================
+//  Timing infrastructure
+//  Set VNS_TIMING to 0 (or compile with -DVNS_TIMING=0) to
+//  remove all overhead for production runs.
+// ============================================================
+#ifndef VNS_TIMING
+#define VNS_TIMING 1
+#endif
+
+#if VNS_TIMING
+    #define VTIME_START(tag)     auto _vt_##tag = std::chrono::steady_clock::now()
+    #define VTIME_STOP(acc, tag) (acc) += std::chrono::steady_clock::now() - _vt_##tag
+#else
+    #define VTIME_START(tag)     ((void)0)
+    #define VTIME_STOP(acc, tag) ((void)0)
+#endif
+
+using Dur = std::chrono::nanoseconds;
+
+// All timing/counter state for one full VNS run
+struct VNSTimings {
+    // --- time buckets ---
+    Dur initLabeling    {0};   // initialRCMLabeling
+    Dur computeBW       {0};   // computeLocalAndGlobalBandwidth (outside IHC)
+    Dur localSearch     {0};   // LocalSearchIHC total
+    Dur shakeTotal      {0};   // entire shake() call
+
+    // breakdown inside shake1
+    Dur s1_shakeData    {0};   // fused computeShakeData (full pass, once per shake1 call)
+    Dur s1_incrUpdate   {0};   // incremental update after each swap
+    Dur s1_selectW      {0};   // selectW inside shake1
+
+    // breakdown inside LocalSearchIHC
+    Dur ihc_computeNP   {0};   // computeNPrime inside IHC
+    Dur ihc_localBW     {0};   // localBandwidth calls inside IHC
+    Dur ihc_fullBW      {0};   // full computeBandwidth inside IHC (rare)
+
+    Dur moveCheck       {0};   // Move() function
+
+    // --- counters ---
+    unsigned long long vnsTotalIter    {0};  // VNS inner loop iterations
+    unsigned long long tRestarts       {0};  // outer t-loop restarts
+    unsigned long long moveAccepted    {0};
+    unsigned long long moveRejected    {0};
+    unsigned long long shake1Calls     {0};
+    unsigned long long shake2Calls     {0};
+    unsigned long long computeBWCalls  {0};  // outside IHC
+    unsigned long long ihcCalls        {0};  // LocalSearchIHC invocations
+    unsigned long long ihcOuterPasses  {0};  // work-list vertex visits (non-stale)
+    unsigned long long ihcSwapAttempts {0};
+    unsigned long long ihcSwapAccepted {0};
+    unsigned long long ihcFullBWCalls  {0};
+
+    void print(std::chrono::steady_clock::time_point wallStart) const {
+        using ms = std::chrono::duration<double, std::milli>;
+
+        auto toMs = [](Dur d) { return std::chrono::duration_cast<ms>(d).count(); };
+        double wallMs = toMs(std::chrono::duration_cast<Dur>(
+            std::chrono::steady_clock::now() - wallStart));
+
+        auto pct = [&](Dur d) -> double {
+            return wallMs > 0 ? (toMs(d) / wallMs) * 100.0 : 0.0;
+        };
+
+        std::cout << "\n========== VNS-Band V3+RCM Timing Report ==========\n";
+        std::cout << std::fixed << std::setprecision(2);
+        std::cout << "  Wall time (total ordering)              : " << wallMs        << " ms\n\n";
+
+        std::cout << "  --- Top-level time buckets ---\n";
+        std::cout << "  initLabeling (RCM)                      : " << toMs(initLabeling)
+                  << " ms  (" << pct(initLabeling)   << " %)\n";
+        std::cout << "  computeLocalAndGlobalBW (outside IHC)  : " << toMs(computeBW)
+                  << " ms  (" << pct(computeBW)       << " %)  x" << computeBWCalls << "\n";
+        std::cout << "  LocalSearchIHC (total)                 : " << toMs(localSearch)
+                  << " ms  (" << pct(localSearch)     << " %)  x" << ihcCalls << "\n";
+        std::cout << "  shake (total)                          : " << toMs(shakeTotal)
+                  << " ms  (" << pct(shakeTotal)      << " %)\n";
+        std::cout << "  Move()                                 : " << toMs(moveCheck)
+                  << " ms  (" << pct(moveCheck)       << " %)\n\n";
+
+        std::cout << "  --- Inside shake ---\n";
+        std::cout << "    shake1 calls                         : " << shake1Calls << "\n";
+        std::cout << "    shake2 calls                         : " << shake2Calls << "\n";
+        std::cout << "    computeShakeData (full, once/call)   : " << toMs(s1_shakeData)
+                  << " ms  (" << pct(s1_shakeData)   << " %)\n";
+        std::cout << "    incremental update (after swap)      : " << toMs(s1_incrUpdate)
+                  << " ms  (" << pct(s1_incrUpdate)  << " %)\n";
+        std::cout << "    selectW                              : " << toMs(s1_selectW)
+                  << " ms  (" << pct(s1_selectW)     << " %)\n\n";
+
+        std::cout << "  --- Inside LocalSearchIHC ---\n";
+        std::cout << "    outer while-loop passes              : " << ihcOuterPasses << "\n";
+        std::cout << "    swap attempts                        : " << ihcSwapAttempts << "\n";
+        std::cout << "    swap accepted                        : " << ihcSwapAccepted << "\n";
+        if (ihcSwapAttempts > 0)
+            std::cout << "    accept rate                          : "
+                      << 100.0 * ihcSwapAccepted / ihcSwapAttempts << " %\n";
+        std::cout << "    computeNPrime                        : " << toMs(ihc_computeNP)
+                  << " ms  (" << pct(ihc_computeNP)  << " %)\n";
+        std::cout << "    localBandwidth calls                 : " << toMs(ihc_localBW)
+                  << " ms  (" << pct(ihc_localBW)    << " %)\n";
+        std::cout << "    computeBandwidth (full, rare)        : " << toMs(ihc_fullBW)
+                  << " ms  (" << pct(ihc_fullBW)     << " %)  x" << ihcFullBWCalls << "\n\n";
+
+        std::cout << "  --- VNS loop counters ---\n";
+        std::cout << "    t-restarts                           : " << tRestarts      << "\n";
+        std::cout << "    VNS inner iterations                 : " << vnsTotalIter   << "\n";
+        std::cout << "    Move accepted                        : " << moveAccepted   << "\n";
+        std::cout << "    Move rejected                        : " << moveRejected   << "\n";
+        std::cout << "================================================\n\n";
+    }
+};
+
+
+//constants that should be changed to work with user input later
+//these constants are currently the same as what was used in the original paper
+constexpr unsigned KMIN        = 5;
+constexpr unsigned KSTEP       = 5;
+constexpr unsigned KPRIME_MAX  = 100;
+constexpr unsigned K_MAX       = 200;
+
+// compute bandwidth B(f)
+static unsigned computeBandwidth(const std::vector<unsigned>& f,
+                                 const unsigned* ptr,
+                                 const unsigned* ind,
+                                 unsigned n)
+{
+    unsigned B = 0;
+    for (unsigned v = 0; v < n; ++v) {
+        const unsigned fv = f[v];
+        for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+            unsigned u = ind[p];
+            if (u == v) continue;
+            unsigned diff = std::abs(static_cast<int>(fv) - static_cast<int>(f[u]));
+            if (diff > B) B = diff;
+        }
+    }
+    return B;
+}
+
+
+static unsigned computeLocalAndGlobalBandwidth(
+    const std::vector<unsigned>& f,
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned n,
+    std::vector<unsigned>& B_local)
+{
+    unsigned B = 0;
+    for (unsigned v = 0; v < n; ++v) {
+        const unsigned fv = f[v];
+        unsigned localMax = 0;
+        for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+            unsigned u = ind[p];
+            unsigned diff = std::abs(static_cast<int>(fv) - static_cast<int>(f[u]));
+            if (diff > localMax) localMax = diff;
+        }
+        B_local[v] = localMax;
+        if (localMax > B) B = localMax;
+    }
+    return B;
+}
+
+
+//takes an array of a current permutation and marks critical vertices
+static void findCriticalVertices(const std::vector<unsigned>& f,
+                                      const unsigned* ptr,
+                                      const unsigned* ind,
+                                      unsigned n,
+                                      unsigned Bf,
+                                      std::vector<char> &isCritical) {
+    isCritical.assign(n, 0);
+    for (unsigned v = 0; v < n; ++v) {
+        const unsigned fv = f[v];
+        for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+            unsigned u = ind[p];
+            if (u == v) continue;
+            unsigned diff = std::abs(static_cast<int>(fv) - static_cast<int>(f[u]));
+            if (diff == Bf) {
+                isCritical[v] = 1;
+                isCritical[u] = 1;
+            }
+        }
+    }
+}
+
+// |V_C(f)| = number of critical vertices under labeling f
+static unsigned countCriticalVertices(const std::vector<unsigned>& f,
+                                      const unsigned* ptr,
+                                      const unsigned* ind,
+                                      unsigned n,
+                                      unsigned Bf,
+                                      std::vector<char> &isCritical)
+{
+    findCriticalVertices(f, ptr, ind, n, Bf, isCritical);
+    unsigned count = 0;
+    for (char c : isCritical) count += static_cast<unsigned>(c != 0);
+    return count;
+}
+
+// takes two permutations a and b, and calculates permutation difference
+static unsigned hammingDistance(const std::vector<unsigned>& a,
+                                const std::vector<unsigned>& b) {
+    const unsigned n = static_cast<unsigned>(a.size());
+    unsigned rho = 0;
+    for (unsigned i = 0; i < n; ++i)
+        if (a[i] != b[i]) ++rho;
+    return rho;
+}
+
+// gives the initial labeling using RCM, mirroring RCMOrdering::orderingFunction()
+// exactly. The matrix's ptr/ind are already symmetrized by SparseViz at startup.
+std::vector<unsigned> initialRCMLabeling(
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned n,
+    std::mt19937& /*rng*/)
+{
+    std::vector<unsigned> queue(n);
+    std::vector<int>      level(n);
+    std::vector<double>   sort_values(n);
+    std::vector<bool>     is_permuted(n, false);
+
+    for (unsigned i = 0; i < n; ++i)
+        sort_values[i] = static_cast<double>(ptr[i + 1] - ptr[i]);
+
+    auto findRoot = [&](unsigned& root, unsigned* q,
+                        int& max_level, unsigned& ccsize) -> bool {
+        for (unsigned i = 0; i < n; ++i) level[i] = -1;
+        q[0] = root;
+        level[root] = 0;
+        unsigned qs = 0, qe = 1;
+        while (qs < qe) {
+            unsigned v = q[qs++];
+            int clevel = level[v];
+            for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+                unsigned nbr = ind[p];
+                if (level[nbr] == -1) {
+                    level[nbr] = clevel + 1;
+                    q[qe++] = nbr;
+                }
+            }
+        }
+        ccsize = qe;
+        if (ccsize == 1) { max_level = 0; return false; }
+        int final_level = level[q[qe - 1]];
+        if (final_level <= max_level) return false;
+        max_level = final_level;
+        root = q[qe - 1];
+        unsigned i = qe - 2;
+        while (i < n && level[q[i]] == final_level) {
+            unsigned v = q[i];
+            if ((ptr[v + 1] - ptr[v]) < (ptr[root + 1] - ptr[root]))
+                root = v;
+            --i;
+        }
+        return true;
+    };
+
+    auto rcmTraversal = [&](unsigned& root, unsigned* q) {
+        q[0] = root;
+        is_permuted[root] = true;
+        unsigned qs = 0, qe = 1;
+        while (qs < qe) {
+            unsigned v = q[qs++];
+            unsigned start_v = qe;
+            for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+                unsigned nbr = ind[p];
+                if (!is_permuted[nbr]) {
+                    q[qe++] = nbr;
+                    is_permuted[nbr] = true;
+                }
+            }
+            for (unsigned i = start_v; i < qe; ++i) {
+                int j = static_cast<int>(i);
+                while (j > static_cast<int>(start_v) &&
+                       sort_values[q[j]] > sort_values[q[j - 1]]) {
+                    std::swap(q[j], q[j - 1]);
+                    --j;
+                }
+            }
+        }
+    };
+
+    unsigned total_permuted = 0;
+    for (unsigned i = 0; i < n; ++i) {
+        if (!is_permuted[i]) {
+            unsigned root = i;
+            int current_level = -1;
+            unsigned ccsize;
+            if (ptr[i + 1] == ptr[i] ||
+                (ptr[i + 1] == ptr[i] + 1 && ind[ptr[i]] == i)) {
+                ccsize = 1;
+                queue[total_permuted] = i;
+                is_permuted[i] = true;
+            } else {
+                while (findRoot(root, queue.data() + total_permuted, current_level, ccsize));
+                rcmTraversal(root, queue.data() + total_permuted);
+            }
+            total_permuted += ccsize;
+        }
+    }
+
+    std::vector<unsigned> f(n);
+    for (unsigned i = 0; i < n; ++i)
+        f[queue[i]] = n - i - 1;
+
+    return f;
+}
+
+// Finds local bandwidth
+// B(f, v): local bandwidth of vertex v
+// f[v]   : label (position) of vertex v
+unsigned localBandwidth(
+    const std::vector<unsigned>& f,
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned v
+)
+{
+    unsigned lbl_v = f[v];
+    unsigned maxDiff = 0;
+
+    for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+        unsigned u = ind[p];
+        if (u == v) continue;
+        auto diff = static_cast<unsigned>(
+            std::abs(static_cast<int>(f[u]) - static_cast<int>(lbl_v))
+        );
+        if (diff > maxDiff) maxDiff = diff;
+    }
+
+    return maxDiff;   // 0 if no neighbors or all same label
+}
+
+// Fused computation of B_local, fmin, fmax, K, and Bprime in a single O(m) pass.
+// Replaces separate computeKandBprime + computeFMinFMax to halve adjacency traversals.
+//
+// All scratch buffers (B_local, sortedVals, fmin, fmax, K) are pre-allocated by
+// the caller and reused across iterations to avoid heap allocation pressure.
+void computeShakeData(
+    const std::vector<unsigned>& f,
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned n,
+    unsigned k,
+    std::vector<unsigned>& K,
+    std::vector<unsigned>& B_local,
+    std::vector<unsigned>& sortedVals,
+    std::vector<unsigned>& fmin,
+    std::vector<unsigned>& fmax,
+    unsigned& Bprime_out
+)
+{
+    // --- 1. Single pass: compute B_local[v], fmin[v], fmax[v] for all vertices ---
+    unsigned globalMax = 0;
+    for (unsigned v = 0; v < n; ++v) {
+        const unsigned fv = f[v];
+        unsigned localMax = 0;
+        bool first = true;
+        unsigned mn = fv, mx = fv;
+
+        for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+            unsigned u = ind[p];
+            if (u == v) continue;
+            unsigned fu = f[u];
+            unsigned diff = std::abs(static_cast<int>(fv) - static_cast<int>(fu));
+            if (diff > localMax) localMax = diff;
+            if (first) {
+                mn = fu; mx = fu; first = false;
+            } else {
+                if (fu < mn) mn = fu;
+                if (fu > mx) mx = fu;
+            }
+        }
+        B_local[v] = localMax;
+        fmin[v] = mn;
+        fmax[v] = mx;
+        if (localMax > globalMax) globalMax = localMax;
+    }
+
+    if (globalMax == 0) {
+        K.clear();
+        Bprime_out = 0;
+        return;
+    }
+
+    // --- 2. Compute B' as the k-th largest B_local value ---
+    // Reuse sortedVals scratch buffer (copy B_local into it)
+    std::copy(B_local.begin(), B_local.begin() + n, sortedVals.begin());
+    unsigned idx = std::min<unsigned>(k - 1, n - 1);
+    std::nth_element(sortedVals.begin(), sortedVals.begin() + idx, sortedVals.end(),
+                     std::greater<unsigned>());
+    unsigned Bprime = sortedVals[idx];
+
+    // --- 3. Build K = { v | B_local[v] >= B' } ---
+    K.clear();
+    for (unsigned v = 0; v < n; ++v) {
+        if (B_local[v] >= Bprime) {
+            K.push_back(v);
+        }
+    }
+
+    Bprime_out = Bprime;
+}
+
+// Selects w according to the Shake-1 criterion.
+// cost(w) = max(|fmax[w]-lbl_v|, |lbl_v-fmin[w]|) — minimised over [fmin_u, fmax_u].
+//
+// Optimizations vs. the original linear scan:
+//   1. Bidirectional outward scan from lbl_v: spatial locality after IHC means
+//      candidates near lbl_v have low cost, so bestCost drops early.
+//   2. c1-pruning: cost >= c1 = |fmax[w]-lbl_v|; skip fmin[w] load if c1 >= bestCost.
+//   3. Early exit when bestCost == 0 (global minimum, cannot improve).
+int selectW(
+    unsigned u,
+    unsigned v,
+    const std::vector<unsigned>& f,
+    const std::vector<unsigned>& fmin,
+    const std::vector<unsigned>& fmax,
+    const std::vector<unsigned>& pos
+)
+{
+    const unsigned fmin_u = fmin[u];
+    const unsigned fmax_u = fmax[u];
+
+    if (fmin_u >= fmax_u)
+        return -1;
+
+    const unsigned lbl_v = f[v];
+
+    // Clamp start to valid range — lbl_v may be slightly outside [fmin_u, fmax_u]
+    // due to label staleness between incremental updates.
+    const int range_lo = static_cast<int>(fmin_u);
+    const int range_hi = static_cast<int>(fmax_u);
+    int start = static_cast<int>(lbl_v);
+    if (start < range_lo) start = range_lo;
+    if (start > range_hi) start = range_hi;
+
+    int bestW = -1;
+    unsigned bestCost = std::numeric_limits<unsigned>::max();
+
+    // lo scans downward from start; hi scans upward from start+1.
+    // Uses signed int to avoid unsigned underflow when lo crosses zero.
+    int lo = start;
+    int hi = start + 1;
+
+    while (lo >= range_lo || hi <= range_hi) {
+        if (lo >= range_lo) {
+            const unsigned w = pos[static_cast<unsigned>(lo)];
+            if (w != u && w != v) {
+                const unsigned c1 = fmax[w] > lbl_v ? fmax[w] - lbl_v : lbl_v - fmax[w];
+                if (c1 < bestCost) {
+                    const unsigned c2 = lbl_v > fmin[w] ? lbl_v - fmin[w] : fmin[w] - lbl_v;
+                    if (c2 < bestCost) {
+                        const unsigned cost = c1 > c2 ? c1 : c2;
+                        if (cost < bestCost) {
+                            bestCost = cost;
+                            bestW    = static_cast<int>(w);
+                            if (bestCost == 0) return bestW;
+                        }
+                    }
+                }
+            }
+            --lo;
+        }
+
+        if (hi <= range_hi) {
+            const unsigned w = pos[static_cast<unsigned>(hi)];
+            if (w != u && w != v) {
+                const unsigned c1 = fmax[w] > lbl_v ? fmax[w] - lbl_v : lbl_v - fmax[w];
+                if (c1 < bestCost) {
+                    const unsigned c2 = lbl_v > fmin[w] ? lbl_v - fmin[w] : fmin[w] - lbl_v;
+                    if (c2 < bestCost) {
+                        const unsigned cost = c1 > c2 ? c1 : c2;
+                        if (cost < bestCost) {
+                            bestCost = cost;
+                            bestW    = static_cast<int>(w);
+                            if (bestCost == 0) return bestW;
+                        }
+                    }
+                }
+            }
+            ++hi;
+        }
+    }
+
+    return bestW;
+}
+
+// actual Shake-1
+void shake1(
+    std::vector<unsigned>& f,
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned n,
+    unsigned k,
+    std::mt19937& rng,
+    VNSTimings& T
+)
+{
+    if (n == 0 || k == 0) return;
+
+    T.shake1Calls++;
+
+    // Pre-allocate all scratch buffers
+    std::vector<unsigned> K;
+    std::vector<unsigned> B_local(n, 0);
+    std::vector<unsigned> sortedVals(n);
+    std::vector<unsigned> fmin(n, 0);
+    std::vector<unsigned> fmax(n, 0);
+    std::vector<unsigned> maxCandidates;
+    unsigned Bprime = 0;
+
+    // pos[label] = vertex; updated O(1) after each swap
+    std::vector<unsigned> pos(n);
+    for (unsigned v = 0; v < n; ++v)
+        pos[f[v]] = v;
+
+    // --- Full O(m) pass once before the loop ---
+    {
+        VTIME_START(sd);
+        computeShakeData(f, ptr, ind, n, k, K, B_local, sortedVals, fmin, fmax, Bprime);
+        VTIME_STOP(T.s1_shakeData, sd);
+    }
+
+    // cnt[b] = number of vertices with B_local[v] == b; enables O(1) updates
+    std::vector<unsigned> cnt(n, 0);
+    for (unsigned v = 0; v < n; ++v)
+        cnt[B_local[v]]++;
+
+    // globalMax: highest b with cnt[b] > 0
+    unsigned globalMax = 0;
+    for (unsigned b = n; b-- > 0; )
+        if (cnt[b] > 0) { globalMax = b; break; }
+
+    // inK[x]=1 iff x is currently in K; posInK[x]=its index in K (valid when inK[x]=1).
+    // Maintained incrementally so K can be updated in O(|affected|) when Bprime is stable.
+    std::vector<char> inK(n, 0);
+    std::vector<unsigned> posInK(n, 0);
+    for (unsigned i = 0; i < static_cast<unsigned>(K.size()); ++i) {
+        inK[K[i]] = 1;
+        posInK[K[i]] = i;
+    }
+
+    // visited[]: deduplicates the affected set; reset only for touched entries
+    std::vector<char> visited(n, 0);
+    std::vector<unsigned> affected;
+    affected.reserve(256);
+
+    // processVertex: rescan x's neighbors to update B_local/fmin/fmax and cnt
+    auto processVertex = [&](unsigned x) {
+        if (visited[x]) return;
+        visited[x] = 1;
+        affected.push_back(x);
+
+        const unsigned old_b = B_local[x];
+        const unsigned fx    = f[x];
+        unsigned localMax = 0;
+        bool first = true;
+        unsigned mn = fx, mx = fx;
+
+        for (unsigned p = ptr[x]; p < ptr[x + 1]; ++p) {
+            unsigned nb = ind[p];
+            if (nb == x) continue;
+            const unsigned fnb  = f[nb];
+            const unsigned diff = (fx > fnb) ? (fx - fnb) : (fnb - fx);
+            if (diff > localMax) localMax = diff;
+            if (first) { mn = fnb; mx = fnb; first = false; }
+            else { if (fnb < mn) mn = fnb; if (fnb > mx) mx = fnb; }
+        }
+
+        B_local[x] = localMax;
+        fmin[x]    = mn;
+        fmax[x]    = mx;
+
+        if (old_b != localMax) {
+            cnt[old_b]--;
+            cnt[localMax]++;
+        }
+    };
+
+    for (unsigned iter = 0; iter < k; ++iter) {
+
+        if (K.empty() || Bprime == 0) break;
+
+        // --- 1. Pick u uniformly at random from K ---
+        std::uniform_int_distribution<unsigned> distU(0, static_cast<unsigned>(K.size() - 1));
+        unsigned u = K[distU(rng)];
+
+        // --- 2. Find v: worst neighbor of u ---
+        unsigned lbl_u = f[u];
+        maxCandidates.clear();
+        unsigned maxDiffUV = 0;
+
+        for (unsigned p = ptr[u]; p < ptr[u + 1]; ++p) {
+            unsigned cand = ind[p];
+            if (cand == u) continue;
+            unsigned diff = (f[cand] > lbl_u) ? (f[cand] - lbl_u) : (lbl_u - f[cand]);
+            if (diff > maxDiffUV) {
+                maxDiffUV = diff;
+                maxCandidates.clear();
+                maxCandidates.push_back(cand);
+            } else if (diff == maxDiffUV) {
+                maxCandidates.push_back(cand);
+            }
+        }
+
+        if (maxCandidates.empty() || maxDiffUV == 0) continue;
+
+        unsigned v;
+        if (maxCandidates.size() == 1) {
+            v = maxCandidates[0];
+        } else {
+            std::uniform_int_distribution<unsigned> distV(0, static_cast<unsigned>(maxCandidates.size() - 1));
+            v = maxCandidates[distV(rng)];
+        }
+
+        // --- 3. Choose w ---
+        int bestW;
+        {
+            VTIME_START(sw);
+            bestW = selectW(u, v, f, fmin, fmax, pos);
+            VTIME_STOP(T.s1_selectW, sw);
+        }
+        if (bestW < 0) continue; // no swap — data still valid for next iteration
+
+        // --- 4. Swap labels of v and w; update pos ---
+        unsigned w = static_cast<unsigned>(bestW);
+        std::swap(f[v], f[w]);
+        pos[f[v]] = v;
+        pos[f[w]] = w;
+
+        // --- 5. Incremental update of B_local/fmin/fmax/cnt/Bprime/K ---
+        // Only vertices in {v,w} ∪ N(v) ∪ N(w) have changed local data.
+        // O(Σ deg(x) for x in affected) + O(n) for K rebuild — replaces O(m) full pass.
+        {
+            VTIME_START(iu);
+
+            // Rescan v, neighbors of v, w, neighbors of w (deduplicated via visited[])
+            processVertex(v);
+            for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+                unsigned nb = ind[p];
+                if (nb != v) processVertex(nb);
+            }
+            processVertex(w);
+            for (unsigned p = ptr[w]; p < ptr[w + 1]; ++p) {
+                unsigned nb = ind[p];
+                if (nb != w) processVertex(nb);
+            }
+
+            // Reset visited flags; keep `affected` alive until after K update
+            for (unsigned x : affected) visited[x] = 0;
+
+            // Update globalMax: scan down until a non-zero cnt bucket
+            while (globalMax > 0 && cnt[globalMax] == 0) --globalMax;
+
+            // Recompute Bprime: k-th largest B_local (scan cnt from top)
+            const unsigned oldBprime = Bprime;
+            if (globalMax == 0) {
+                Bprime = 0;
+            } else {
+                const unsigned idx = std::min<unsigned>(k - 1, n - 1);
+                unsigned cumsum = 0;
+                Bprime = 0;
+                for (unsigned b = globalMax; ; --b) {
+                    cumsum += cnt[b];
+                    if (cumsum > idx) { Bprime = b; break; }
+                    if (b == 0) break;
+                }
+            }
+
+            // Update K
+            if (Bprime == oldBprime) {
+                // Bprime unchanged: only vertices in `affected` can have changed
+                // membership. Update K in O(|affected|) using inK/posInK.
+                for (unsigned x : affected) {
+                    const bool shouldBeIn = (B_local[x] >= Bprime);
+                    if (shouldBeIn && !inK[x]) {
+                        posInK[x] = static_cast<unsigned>(K.size());
+                        K.push_back(x);
+                        inK[x] = 1;
+                    } else if (!shouldBeIn && inK[x]) {
+                        // O(1) swap-erase
+                        const unsigned pos_x = posInK[x];
+                        const unsigned last  = K.back();
+                        K[pos_x]    = last;
+                        posInK[last] = pos_x;
+                        K.pop_back();
+                        inK[x] = 0;
+                    }
+                }
+            } else {
+                // Bprime changed: full O(n) rebuild required
+                K.clear();
+                std::fill(inK.begin(), inK.end(), 0);
+                for (unsigned x = 0; x < n; ++x) {
+                    if (B_local[x] >= Bprime) {
+                        posInK[x] = static_cast<unsigned>(K.size());
+                        K.push_back(x);
+                        inK[x] = 1;
+                    }
+                }
+            }
+
+            affected.clear();
+
+            VTIME_STOP(T.s1_incrUpdate, iu);
+        }
+    }
+}
+
+// `Shake` step 2: randomly rotates an interval repeated k times
+void shake2(
+    std::vector<unsigned>& f,
+    unsigned Bf,
+    unsigned k,
+    std::mt19937& rng,
+    VNSTimings& T
+) {
+    T.shake2Calls++;
+    if (k==0) return;
+    const unsigned n = f.size();
+    if (n < 3) return;
+
+    // Build inverse permutation p[label] = vertex
+    std::vector<unsigned> p(n);
+    for (unsigned v = 0; v < n; ++v)
+        p[f[v]] = v;
+    for (unsigned iter = 0; iter < k; ++iter)
+    {
+        unsigned beginning = std::uniform_int_distribution<unsigned>(0, n - 1)(rng);
+
+        // guard against too small Bf so upper bound >= 2
+        unsigned maxLen = (Bf > 3 ? std::min(20u, Bf / 2) : 2u);
+        if (maxLen < 2) continue;
+
+        unsigned ending = beginning + std::uniform_int_distribution<unsigned>(2, maxLen)(rng);
+
+        if (ending > n - 1)
+            ending = n - 1;
+
+        if (ending <= beginning + 1)
+            continue; // skip this iteration
+
+        unsigned innerLen = ending - beginning - 1;
+        if (innerLen == 0) continue;
+
+        unsigned middle = std::uniform_int_distribution<unsigned>(1, innerLen)(rng);
+
+        // Save original vertex-at-label for the range before rotating.
+        // (segLen <= 21 since maxLen <= 20; fits on stack.)
+        // Without this, p[j] in the update loop may already be overwritten
+        // by an earlier iteration of that same loop, causing the wrong vertex
+        // to be fetched and producing duplicate labels in f.
+        unsigned orig[21];
+        for (unsigned j = beginning; j <= ending; ++j)
+            orig[j - beginning] = p[j];
+
+        // Rotate f and update pos atomically using saved originals.
+        for (unsigned j = beginning; j <= ending; ++j) {
+            const unsigned vertex    = orig[j - beginning];
+            const unsigned new_label = (j >= beginning + middle)
+                                       ? (j - middle)
+                                       : (j + ending - beginning - middle + 1);
+            f[vertex]    = new_label;
+            p[new_label] = vertex;
+        }
+    }
+}
+
+// SHAKE PROPER
+void shake(
+    std::vector<unsigned>& f,
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned n,
+    unsigned k,
+    unsigned k_min,
+    unsigned k_step,
+    unsigned kprime_max,
+    unsigned Bf,
+    std::mt19937& rng,
+    VNSTimings& T
+) {
+    if (k <= kprime_max) {
+        shake1(f, ptr, ind, n, k, rng, T);
+    } else {
+        unsigned kprime = (k - k_min) / k_step;
+        shake2(f, Bf, kprime, rng, T);
+    }
+}
+
+// Move or not function: decide if fPrime is "better" than f
+bool Move(const std::vector<unsigned>& f,
+          const std::vector<unsigned>& fPrime,
+          const unsigned* ptr,
+          const unsigned* ind,
+          unsigned n,
+          unsigned alpha,
+          const unsigned& Bf,
+          const unsigned& Bfp)
+{
+    if (Bfp < Bf) return true;
+
+    if (Bfp == Bf) {
+
+        const unsigned rho = hammingDistance(f, fPrime);
+        if (rho > alpha) return true;
+
+        std::vector<char> isCriticalF(n,0);
+        std::vector<char> isCriticalFprime(n,0);
+        const unsigned VCf  = countCriticalVertices(f,      ptr, ind, n, Bf, isCriticalF);
+        const unsigned VCfp = countCriticalVertices(fPrime, ptr, ind, n, Bfp, isCriticalFprime);
+
+        if (VCfp < VCf) return true;
+    }
+
+    return false;
+}
+
+
+void computeNPrime(
+    const std::vector<unsigned>& f,
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned n,
+    unsigned v,
+    std::vector<unsigned>& nprime
+) {
+    nprime.clear();
+    if (n == 0 || v >= n) return;
+
+    unsigned mn = f[v], mx = f[v];
+    bool first = true;
+    for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+        unsigned u = ind[p];
+        if (u == v) continue;
+        if (first) { mn = f[u]; mx = f[u]; first = false; }
+        else {
+            if (f[u] < mn) mn = f[u];
+            if (f[u] > mx) mx = f[u];
+        }
+    }
+
+    unsigned mid = (mn + mx) / 2;
+    unsigned dv = (mid > f[v]) ? (mid - f[v]) : (f[v] - mid);
+
+    for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+        unsigned u = ind[p];
+        if (u == v) continue;
+        unsigned du = (mid > f[u]) ? (mid - f[u]) : (f[u] - mid);
+        if (du < dv) {
+            nprime.push_back(u);
+        }
+    }
+
+    std::sort(nprime.begin(), nprime.end(),
+          [&](unsigned a, unsigned b) {
+              unsigned da = (mid > f[a]) ? (mid - f[a]) : (f[a] - mid);
+              unsigned db = (mid > f[b]) ? (mid - f[b]) : (f[b] - mid);
+              return da < db;
+          });
+}
+
+
+void LocalSearchIHC(std::vector<unsigned>& f, unsigned n, unsigned& Bf,
+                    const unsigned* ptr, const unsigned* ind,
+                    std::vector<unsigned>& B_local,
+                    VNSTimings& T)
+{
+    T.ihcCalls++;
+    bool canImprove = true;
+    std::vector<char> criticalVertices;
+    findCriticalVertices(f, ptr, ind, n, Bf, criticalVertices);
+    unsigned criticalCount = 0;
+    for (char c : criticalVertices) criticalCount += static_cast<unsigned>(c != 0);
+    std::vector<unsigned> nPrimeV;  // pre-allocate outside loops
+
+    // cnt[b] = number of vertices with B_local[v] == b; lets us find max(B_local) without
+    // a full O(m) edge scan — same technique as shake1's incremental update.
+    std::vector<unsigned> cnt(n, 0);
+    for (unsigned w = 0; w < n; ++w)
+        cnt[B_local[w]]++;
+    unsigned globalBW = Bf;  // tracks max(B_local), equals Bf initially
+
+    while (canImprove) {
+        canImprove = false;
+        T.ihcOuterPasses++;
+        for (unsigned v = 0; v < n; ++v)
+        {
+            if (criticalVertices[v] != 1) continue;
+
+            {
+                VTIME_START(cnp);
+                computeNPrime(f, ptr, ind, n, v, nPrimeV);
+                VTIME_STOP(T.ihc_computeNP, cnp);
+            }
+            if (nPrimeV.empty()) continue;
+
+            for (unsigned i = 0; i < nPrimeV.size(); ++i)
+            {
+                T.ihcSwapAttempts++;
+                unsigned u = nPrimeV[i];
+
+                // tentatively swap in-place
+                std::swap(f[v], f[u]);
+
+                unsigned newBW_v, newBW_u;
+                {
+                    VTIME_START(lbw);
+                    newBW_v = localBandwidth(f, ptr, ind, v);
+                    VTIME_STOP(T.ihc_localBW, lbw);
+                }
+                if (newBW_v > Bf) { std::swap(f[v], f[u]); continue; }
+
+                {
+                    VTIME_START(lbw2);
+                    newBW_u = localBandwidth(f, ptr, ind, u);
+                    VTIME_STOP(T.ihc_localBW, lbw2);
+                }
+                if (newBW_u > Bf) { std::swap(f[v], f[u]); continue; }
+
+                // Theorem 1: compute C' values
+                // C'(x) = 2 if local BW > Bf (already rejected above)
+                // C'(x) = 1 if local BW == Bf
+                // C'(x) = 0 if local BW < Bf
+                unsigned Cprime_v = (newBW_v == Bf) ? 1 : 0;
+                unsigned Cprime_u = (newBW_u == Bf) ? 1 : 0;
+                unsigned C_v = static_cast<unsigned char>(criticalVertices[v]);
+                unsigned C_u = static_cast<unsigned char>(criticalVertices[u]);
+
+                if (Cprime_u <= C_u &&
+                    Cprime_v <= C_v &&
+                    Cprime_u + Cprime_v < C_u + C_v)
+                {
+                    T.ihcSwapAccepted++;
+                    // accepted — update Bf and critical vertices
+
+                    // update B_local for affected vertices; keep cnt in sync
+                    cnt[B_local[v]]--; B_local[v] = newBW_v; cnt[newBW_v]++;
+                    cnt[B_local[u]]--; B_local[u] = newBW_u; cnt[newBW_u]++;
+                    for (unsigned p = ptr[v]; p < ptr[v+1]; ++p) {
+                        unsigned w = ind[p];
+                        if (w != v) {
+                            VTIME_START(lbwN);
+                            unsigned newB = localBandwidth(f, ptr, ind, w);
+                            VTIME_STOP(T.ihc_localBW, lbwN);
+                            if (B_local[w] != newB) { cnt[B_local[w]]--; cnt[newB]++; }
+                            B_local[w] = newB;
+                        }
+                    }
+                    for (unsigned p = ptr[u]; p < ptr[u+1]; ++p) {
+                        unsigned w = ind[p];
+                        if (w != u) {
+                            VTIME_START(lbwN2);
+                            unsigned newB = localBandwidth(f, ptr, ind, w);
+                            VTIME_STOP(T.ihc_localBW, lbwN2);
+                            if (B_local[w] != newB) { cnt[B_local[w]]--; cnt[newB]++; }
+                            B_local[w] = newB;
+                        }
+                    }
+                    // advance globalBW down to the new max(B_local)
+                    while (globalBW > 0 && cnt[globalBW] == 0) --globalBW;
+
+                    // check if bandwidth actually decreased
+                    if (Cprime_v == 0 && Cprime_u == 0 && criticalCount == 2) {
+                        T.ihcFullBWCalls++;
+                        VTIME_START(fbw);
+                        // globalBW = max(B_local) maintained by cnt — no O(m) edge scan needed
+                        unsigned newBf = globalBW;
+                        VTIME_STOP(T.ihc_fullBW, fbw);
+                        if (newBf < Bf) {
+                            Bf = newBf;  // globalBW already equals newBf from the scan above
+                            // Bf decreased: vertices far from v,u may be newly critical.
+                            // Rebuild criticalVertices and criticalCount from stored B_local
+                            // (O(n), no edge traversal — B_local is correct for all vertices).
+                            criticalCount = 0;
+                            for (unsigned w = 0; w < n; ++w) {
+                                criticalVertices[w] = (B_local[w] == Bf) ? 1 : 0;
+                                criticalCount += criticalVertices[w];
+                            }
+                            canImprove = true;
+                            break;
+                        }
+                    }
+
+                    // update criticalVertices and criticalCount for v, u, and their neighbors
+                    auto updateCrit = [&](unsigned w) {
+                        char newCrit = (B_local[w] == Bf) ? 1 : 0;
+                        if (newCrit != criticalVertices[w]) {
+                            criticalCount += newCrit - criticalVertices[w];
+                            criticalVertices[w] = newCrit;
+                        }
+                    };
+                    for (unsigned w : {v, u}) {
+                        updateCrit(w);
+                        for (unsigned p = ptr[w]; p < ptr[w+1]; ++p) {
+                            unsigned x = ind[p];
+                            if (x == w) continue;
+                            updateCrit(x);
+                        }
+                    }
+                    canImprove = true;
+                    break;
+                }
+                // rejected. swap back
+                std::swap(f[v], f[u]);
+            }
+        }
+    }
+    Bf = globalBW;
+}
+
+
+// VNS-Band main loop
+void vnsBand(
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned n,
+    unsigned t_max,
+    unsigned alpha,
+    std::vector<unsigned>& bestF,
+    std::mt19937& rng,
+    unsigned long long& iCount,
+    std::chrono::steady_clock::time_point deadline
+) {
+    if (n == 0) return;
+
+    VNSTimings T;
+    auto wallStart = std::chrono::steady_clock::now();
+
+    // best bandwidth seen so far: B*
+    unsigned B_star = std::numeric_limits<unsigned>::max();
+
+    const unsigned I_MAX = (K_MAX - KMIN) / KSTEP;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        for (unsigned t = 0; t < t_max; ++t) {
+            T.tRestarts++;
+
+            std::vector<unsigned> f;
+            {
+                VTIME_START(init);
+                f = initialRCMLabeling(ptr, ind, n, rng);
+                VTIME_STOP(T.initLabeling, init);
+            }
+
+            std::vector<unsigned> B_local(n, 0);
+            unsigned Bf;
+            {
+                VTIME_START(bw0);
+                Bf = computeLocalAndGlobalBandwidth(f, ptr, ind, n, B_local);
+                VTIME_STOP(T.computeBW, bw0);
+                T.computeBWCalls++;
+            }
+
+            {
+                VTIME_START(ihc0);
+                LocalSearchIHC(f, n, Bf, ptr, ind, B_local, T);
+                VTIME_STOP(T.localSearch, ihc0);
+            }
+
+            unsigned i = 0;
+            unsigned k = KMIN;
+
+            // OPT: pre-allocate fPrime and Bf_prime_local outside the inner loop
+            // to avoid repeated O(n) heap allocations per iteration.
+            std::vector<unsigned> fPrime(n);
+            std::vector<unsigned> Bf_prime_local(n);
+
+            while (i <= I_MAX && std::chrono::steady_clock::now() < deadline) {
+                T.vnsTotalIter++;
+                iCount++;
+                if (iCount % 100 == 0)
+                    std::cout << "VNS V3+RCM iteration i= " << iCount << std::endl;
+
+                // reuse pre-allocated buffers
+                fPrime.assign(f.begin(), f.end());
+                {
+                    VTIME_START(shk);
+                    shake(fPrime, ptr, ind, n, k, KMIN, KSTEP, KPRIME_MAX, Bf, rng, T);
+                    VTIME_STOP(T.shakeTotal, shk);
+                }
+
+                unsigned Bf_prime;
+                {
+                    VTIME_START(bw1);
+                    Bf_prime = computeLocalAndGlobalBandwidth(fPrime, ptr, ind, n, Bf_prime_local);
+                    VTIME_STOP(T.computeBW, bw1);
+                    T.computeBWCalls++;
+                }
+
+                {
+                    VTIME_START(ihc1);
+                    LocalSearchIHC(fPrime, n, Bf_prime, ptr, ind, Bf_prime_local, T);
+                    VTIME_STOP(T.localSearch, ihc1);
+                }
+
+                bool moved;
+                {
+                    VTIME_START(mv);
+                    moved = Move(f, fPrime, ptr, ind, n, alpha, Bf, Bf_prime);
+                    VTIME_STOP(T.moveCheck, mv);
+                }
+
+                if (moved) {
+                    T.moveAccepted++;
+                    f.swap(fPrime);
+                    Bf = Bf_prime;
+                    k = KMIN;
+                    i = 0;
+                } else {
+                    T.moveRejected++;
+                    k += KSTEP;
+                    ++i;
+                }
+            }
+
+            if (Bf < B_star) {
+                B_star = Bf;
+                bestF = f;
+            }
+        }
+    }
+
+    T.print(wallStart);
+}
+
+
+void VNSBandOrdering::orderingFunction() {
+
+    const SparseMatrix& M = this->getMatrix();
+    const unsigned nr = M.getRowCount();
+    const unsigned nc = M.getColCount();
+
+    if (nr == 0) return;
+
+    const unsigned* ptrRaw = M.getPtr();
+    const unsigned* indRaw = M.getInd();
+
+    std::vector<unsigned> bestF;
+
+    // Later user input
+    const unsigned T_MAX_ITERS = 20;
+    const unsigned ALPHA       = 10;
+    thread_local std::mt19937 rng(std::random_device{}());
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::minutes(15);
+
+    unsigned long long iCount = 0;
+
+    vnsBand(ptrRaw, indRaw, nr, T_MAX_ITERS, ALPHA, bestF, rng, iCount, deadline);
+
+    rowIPermutation = new vType[nr];
+    for (unsigned v = 0; v < nr; ++v) {
+        rowIPermutation[v] = bestF[v];
+    }
+
+    colIPermutation = new vType[nc];
+    if (nr == nc) {
+        for (unsigned v = 0; v < nc; ++v)
+            colIPermutation[v] = rowIPermutation[v];
+    } else {
+        for (unsigned j = 0; j < nc; ++j)
+            colIPermutation[j] = j;
+    }
+}

--- a/src/Matrix/Orderings/VNSBandOrderingV3.cpp
+++ b/src/Matrix/Orderings/VNSBandOrderingV3.cpp
@@ -1,0 +1,1144 @@
+// Created by grkmshn on 11/20/25.
+
+#include "VNSBandOrdering.h"
+#include <vector>
+#include <random>
+#include <cstddef>
+#include <algorithm>
+#include <limits>
+#include <cmath>
+#include <chrono>
+#include <iostream>
+#include <iomanip>
+#include <numeric>
+#include <string>
+
+// ============================================================
+//  Timing infrastructure
+//  Set VNS_TIMING to 0 (or compile with -DVNS_TIMING=0) to
+//  remove all overhead for production runs.
+// ============================================================
+#ifndef VNS_TIMING
+#define VNS_TIMING 1
+#endif
+
+#if VNS_TIMING
+    #define VTIME_START(tag)     auto _vt_##tag = std::chrono::steady_clock::now()
+    #define VTIME_STOP(acc, tag) (acc) += std::chrono::steady_clock::now() - _vt_##tag
+#else
+    #define VTIME_START(tag)     ((void)0)
+    #define VTIME_STOP(acc, tag) ((void)0)
+#endif
+
+using Dur = std::chrono::nanoseconds;
+
+// All timing/counter state for one full VNS run
+struct VNSTimings {
+    // --- time buckets ---
+    Dur initLabeling    {0};   // initialVNSBandLabeling
+    Dur computeBW       {0};   // computeLocalAndGlobalBandwidth (outside IHC)
+    Dur localSearch     {0};   // LocalSearchIHC total
+    Dur shakeTotal      {0};   // entire shake() call
+
+    // breakdown inside shake1
+    Dur s1_shakeData    {0};   // fused computeShakeData (full pass, once per shake1 call)
+    Dur s1_incrUpdate   {0};   // incremental update after each swap
+    Dur s1_selectW      {0};   // selectW inside shake1
+
+    // breakdown inside LocalSearchIHC
+    Dur ihc_computeNP   {0};   // computeNPrime inside IHC
+    Dur ihc_localBW     {0};   // localBandwidth calls inside IHC
+    Dur ihc_fullBW      {0};   // full computeBandwidth inside IHC (rare)
+
+    Dur moveCheck       {0};   // Move() function
+
+    // --- counters ---
+    unsigned long long vnsTotalIter    {0};  // VNS inner loop iterations
+    unsigned long long tRestarts       {0};  // outer t-loop restarts
+    unsigned long long moveAccepted    {0};
+    unsigned long long moveRejected    {0};
+    unsigned long long shake1Calls     {0};
+    unsigned long long shake2Calls     {0};
+    unsigned long long computeBWCalls  {0};  // outside IHC
+    unsigned long long ihcCalls        {0};  // LocalSearchIHC invocations
+    unsigned long long ihcOuterPasses  {0};  // work-list vertex visits (non-stale)
+    unsigned long long ihcSwapAttempts {0};
+    unsigned long long ihcSwapAccepted {0};
+    unsigned long long ihcFullBWCalls  {0};
+
+    void print(std::chrono::steady_clock::time_point wallStart) const {
+        using ms = std::chrono::duration<double, std::milli>;
+
+        auto toMs = [](Dur d) { return std::chrono::duration_cast<ms>(d).count(); };
+        double wallMs = toMs(std::chrono::duration_cast<Dur>(
+            std::chrono::steady_clock::now() - wallStart));
+
+        auto pct = [&](Dur d) -> double {
+            return wallMs > 0 ? (toMs(d) / wallMs) * 100.0 : 0.0;
+        };
+
+        std::cout << "\n========== VNS-Band V4 Timing Report ==========\n";
+        std::cout << std::fixed << std::setprecision(2);
+        std::cout << "  Wall time (total ordering)              : " << wallMs        << " ms\n\n";
+
+        std::cout << "  --- Top-level time buckets ---\n";
+        std::cout << "  initLabeling                            : " << toMs(initLabeling)
+                  << " ms  (" << pct(initLabeling)   << " %)\n";
+        std::cout << "  computeLocalAndGlobalBW (outside IHC)  : " << toMs(computeBW)
+                  << " ms  (" << pct(computeBW)       << " %)  x" << computeBWCalls << "\n";
+        std::cout << "  LocalSearchIHC (total)                 : " << toMs(localSearch)
+                  << " ms  (" << pct(localSearch)     << " %)  x" << ihcCalls << "\n";
+        std::cout << "  shake (total)                          : " << toMs(shakeTotal)
+                  << " ms  (" << pct(shakeTotal)      << " %)\n";
+        std::cout << "  Move()                                 : " << toMs(moveCheck)
+                  << " ms  (" << pct(moveCheck)       << " %)\n\n";
+
+        std::cout << "  --- Inside shake ---\n";
+        std::cout << "    shake1 calls                         : " << shake1Calls << "\n";
+        std::cout << "    shake2 calls                         : " << shake2Calls << "\n";
+        std::cout << "    computeShakeData (full, once/call)   : " << toMs(s1_shakeData)
+                  << " ms  (" << pct(s1_shakeData)   << " %)\n";
+        std::cout << "    incremental update (after swap)      : " << toMs(s1_incrUpdate)
+                  << " ms  (" << pct(s1_incrUpdate)  << " %)\n";
+        std::cout << "    selectW                              : " << toMs(s1_selectW)
+                  << " ms  (" << pct(s1_selectW)     << " %)\n\n";
+
+        std::cout << "  --- Inside LocalSearchIHC ---\n";
+        std::cout << "    outer while-loop passes              : " << ihcOuterPasses << "\n";
+        std::cout << "    swap attempts                        : " << ihcSwapAttempts << "\n";
+        std::cout << "    swap accepted                        : " << ihcSwapAccepted << "\n";
+        if (ihcSwapAttempts > 0)
+            std::cout << "    accept rate                          : "
+                      << 100.0 * ihcSwapAccepted / ihcSwapAttempts << " %\n";
+        std::cout << "    computeNPrime                        : " << toMs(ihc_computeNP)
+                  << " ms  (" << pct(ihc_computeNP)  << " %)\n";
+        std::cout << "    localBandwidth calls                 : " << toMs(ihc_localBW)
+                  << " ms  (" << pct(ihc_localBW)    << " %)\n";
+        std::cout << "    computeBandwidth (full, rare)        : " << toMs(ihc_fullBW)
+                  << " ms  (" << pct(ihc_fullBW)     << " %)  x" << ihcFullBWCalls << "\n\n";
+
+        std::cout << "  --- VNS loop counters ---\n";
+        std::cout << "    t-restarts                           : " << tRestarts      << "\n";
+        std::cout << "    VNS inner iterations                 : " << vnsTotalIter   << "\n";
+        std::cout << "    Move accepted                        : " << moveAccepted   << "\n";
+        std::cout << "    Move rejected                        : " << moveRejected   << "\n";
+        std::cout << "================================================\n\n";
+    }
+};
+
+
+//constants that should be changed to work with user input later
+//these constants are currently the same as what was used in the original paper
+constexpr unsigned KMIN        = 5;
+constexpr unsigned KSTEP       = 5;
+constexpr unsigned KPRIME_MAX  = 100;
+constexpr unsigned K_MAX       = 200;
+
+// compute bandwidth B(f)
+static unsigned computeBandwidth(const std::vector<unsigned>& f,
+                                 const unsigned* ptr,
+                                 const unsigned* ind,
+                                 unsigned n)
+{
+    unsigned B = 0;
+    for (unsigned v = 0; v < n; ++v) {
+        const unsigned fv = f[v];
+        for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+            unsigned u = ind[p];
+            if (u == v) continue;
+            unsigned diff = std::abs(static_cast<int>(fv) - static_cast<int>(f[u]));
+            if (diff > B) B = diff;
+        }
+    }
+    return B;
+}
+
+
+static unsigned computeLocalAndGlobalBandwidth(
+    const std::vector<unsigned>& f,
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned n,
+    std::vector<unsigned>& B_local)
+{
+    unsigned B = 0;
+    for (unsigned v = 0; v < n; ++v) {
+        const unsigned fv = f[v];
+        unsigned localMax = 0;
+        for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+            unsigned u = ind[p];
+            unsigned diff = std::abs(static_cast<int>(fv) - static_cast<int>(f[u]));
+            if (diff > localMax) localMax = diff;
+        }
+        B_local[v] = localMax;
+        if (localMax > B) B = localMax;
+    }
+    return B;
+}
+
+
+//takes an array of a current permutation and marks critical vertices
+static void findCriticalVertices(const std::vector<unsigned>& f,
+                                      const unsigned* ptr,
+                                      const unsigned* ind,
+                                      unsigned n,
+                                      unsigned Bf,
+                                      std::vector<char> &isCritical) {
+    isCritical.assign(n, 0);
+    for (unsigned v = 0; v < n; ++v) {
+        const unsigned fv = f[v];
+        for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+            unsigned u = ind[p];
+            if (u == v) continue;
+            unsigned diff = std::abs(static_cast<int>(fv) - static_cast<int>(f[u]));
+            if (diff == Bf) {
+                isCritical[v] = 1;
+                isCritical[u] = 1;
+            }
+        }
+    }
+}
+
+// |V_C(f)| = number of critical vertices under labeling f
+static unsigned countCriticalVertices(const std::vector<unsigned>& f,
+                                      const unsigned* ptr,
+                                      const unsigned* ind,
+                                      unsigned n,
+                                      unsigned Bf,
+                                      std::vector<char> &isCritical)
+{
+    findCriticalVertices(f, ptr, ind, n, Bf, isCritical);
+    unsigned count = 0;
+    for (char c : isCritical) count += static_cast<unsigned>(c != 0);
+    return count;
+}
+
+// takes two permutations a and b, and calculates permutation difference
+static unsigned hammingDistance(const std::vector<unsigned>& a,
+                                const std::vector<unsigned>& b) {
+    const unsigned n = static_cast<unsigned>(a.size());
+    unsigned rho = 0;
+    for (unsigned i = 0; i < n; ++i)
+        if (a[i] != b[i]) ++rho;
+    return rho;
+}
+
+// gives the initial labeling using randomized BFS with per-level rotation
+std::vector<unsigned> initialVNSBandLabeling(
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned n,
+    std::mt19937& rng)
+{
+    std::vector<unsigned> labels(n, 0);
+    std::vector<bool> visited(n, false);
+
+
+    // used for randomly choosing starting vertex, required for disconnected matrices
+    auto pickRandomUnvisited = [&]() -> int {
+        for (;;) {
+            unsigned v = rng() % n;
+            if (!visited[v]) return v;
+        }
+    };
+
+    std::vector<unsigned> currentLevel;
+    std::vector<unsigned> nextLevel;
+    unsigned nextLabel = 0;
+
+    while (nextLabel < n) {
+
+        if (currentLevel.empty()) {
+            int root = pickRandomUnvisited();
+            visited[root] = true;
+            currentLevel.push_back(root);
+        }
+
+        nextLevel.clear();
+        for (unsigned v : currentLevel) {
+            for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+                unsigned u = ind[p];
+                if (u == v) continue;
+                if (!visited[u]) {
+                    visited[u] = true;
+                    nextLevel.push_back(u);
+                }
+            }
+        }
+
+        const size_t currentCount = currentLevel.size();
+        if (currentCount > 0) {
+            // random rotation of current level
+            std::uniform_int_distribution<size_t> distRot(0, currentCount - 1);
+            size_t rotStart = distRot(rng);
+
+            for (size_t k = 0; k < currentCount; ++k) {
+                unsigned v = currentLevel[rotStart];
+                labels[v] = nextLabel;
+                ++nextLabel;
+
+                ++rotStart;
+                if (rotStart == currentCount) rotStart = 0;
+            }
+        }
+
+        currentLevel.swap(nextLevel);
+    }
+
+    return labels;
+}
+
+// Finds local bandwidth
+// B(f, v): local bandwidth of vertex v
+// f[v]   : label (position) of vertex v
+unsigned localBandwidth(
+    const std::vector<unsigned>& f,
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned v
+)
+{
+    unsigned lbl_v = f[v];
+    unsigned maxDiff = 0;
+
+    for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+        unsigned u = ind[p];
+        if (u == v) continue;
+        auto diff = static_cast<unsigned>(
+            std::abs(static_cast<int>(f[u]) - static_cast<int>(lbl_v))
+        );
+        if (diff > maxDiff) maxDiff = diff;
+    }
+
+    return maxDiff;   // 0 if no neighbors or all same label
+}
+
+// Fused computation of B_local, fmin, fmax, K, and Bprime in a single O(m) pass.
+// Replaces separate computeKandBprime + computeFMinFMax to halve adjacency traversals.
+//
+// All scratch buffers (B_local, sortedVals, fmin, fmax, K) are pre-allocated by
+// the caller and reused across iterations to avoid heap allocation pressure.
+void computeShakeData(
+    const std::vector<unsigned>& f,
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned n,
+    unsigned k,
+    std::vector<unsigned>& K,
+    std::vector<unsigned>& B_local,
+    std::vector<unsigned>& sortedVals,
+    std::vector<unsigned>& fmin,
+    std::vector<unsigned>& fmax,
+    unsigned& Bprime_out
+)
+{
+    // --- 1. Single pass: compute B_local[v], fmin[v], fmax[v] for all vertices ---
+    unsigned globalMax = 0;
+    for (unsigned v = 0; v < n; ++v) {
+        const unsigned fv = f[v];
+        unsigned localMax = 0;
+        bool first = true;
+        unsigned mn = fv, mx = fv;
+
+        for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+            unsigned u = ind[p];
+            if (u == v) continue;
+            unsigned fu = f[u];
+            unsigned diff = std::abs(static_cast<int>(fv) - static_cast<int>(fu));
+            if (diff > localMax) localMax = diff;
+            if (first) {
+                mn = fu; mx = fu; first = false;
+            } else {
+                if (fu < mn) mn = fu;
+                if (fu > mx) mx = fu;
+            }
+        }
+        B_local[v] = localMax;
+        fmin[v] = mn;
+        fmax[v] = mx;
+        if (localMax > globalMax) globalMax = localMax;
+    }
+
+    if (globalMax == 0) {
+        K.clear();
+        Bprime_out = 0;
+        return;
+    }
+
+    // --- 2. Compute B' as the k-th largest B_local value ---
+    // Reuse sortedVals scratch buffer (copy B_local into it)
+    std::copy(B_local.begin(), B_local.begin() + n, sortedVals.begin());
+    unsigned idx = std::min<unsigned>(k - 1, n - 1);
+    std::nth_element(sortedVals.begin(), sortedVals.begin() + idx, sortedVals.end(),
+                     std::greater<unsigned>());
+    unsigned Bprime = sortedVals[idx];
+
+    // --- 3. Build K = { v | B_local[v] >= B' } ---
+    K.clear();
+    for (unsigned v = 0; v < n; ++v) {
+        if (B_local[v] >= Bprime) {
+            K.push_back(v);
+        }
+    }
+
+    Bprime_out = Bprime;
+}
+
+// Selects w according to the Shake-1 criterion.
+// cost(w) = max(|fmax[w]-lbl_v|, |lbl_v-fmin[w]|) — minimised over [fmin_u, fmax_u].
+//
+// Optimizations vs. the original linear scan:
+//   1. Bidirectional outward scan from lbl_v: spatial locality after IHC means
+//      candidates near lbl_v have low cost, so bestCost drops early.
+//   2. c1-pruning: cost >= c1 = |fmax[w]-lbl_v|; skip fmin[w] load if c1 >= bestCost.
+//   3. Early exit when bestCost == 0 (global minimum, cannot improve).
+int selectW(
+    unsigned u,
+    unsigned v,
+    const std::vector<unsigned>& f,
+    const std::vector<unsigned>& fmin,
+    const std::vector<unsigned>& fmax,
+    const std::vector<unsigned>& pos
+)
+{
+    const unsigned fmin_u = fmin[u];
+    const unsigned fmax_u = fmax[u];
+
+    if (fmin_u >= fmax_u)
+        return -1;
+
+    const unsigned lbl_v = f[v];
+
+    // Clamp start to valid range — lbl_v may be slightly outside [fmin_u, fmax_u]
+    // due to label staleness between incremental updates.
+    const int range_lo = static_cast<int>(fmin_u);
+    const int range_hi = static_cast<int>(fmax_u);
+    int start = static_cast<int>(lbl_v);
+    if (start < range_lo) start = range_lo;
+    if (start > range_hi) start = range_hi;
+
+    int bestW = -1;
+    unsigned bestCost = std::numeric_limits<unsigned>::max();
+
+    // lo scans downward from start; hi scans upward from start+1.
+    // Uses signed int to avoid unsigned underflow when lo crosses zero.
+    int lo = start;
+    int hi = start + 1;
+
+    while (lo >= range_lo || hi <= range_hi) {
+        if (lo >= range_lo) {
+            const unsigned w = pos[static_cast<unsigned>(lo)];
+            if (w != u && w != v) {
+                const unsigned c1 = fmax[w] > lbl_v ? fmax[w] - lbl_v : lbl_v - fmax[w];
+                if (c1 < bestCost) {
+                    const unsigned c2 = lbl_v > fmin[w] ? lbl_v - fmin[w] : fmin[w] - lbl_v;
+                    if (c2 < bestCost) {
+                        const unsigned cost = c1 > c2 ? c1 : c2;
+                        if (cost < bestCost) {
+                            bestCost = cost;
+                            bestW    = static_cast<int>(w);
+                            if (bestCost == 0) return bestW;
+                        }
+                    }
+                }
+            }
+            --lo;
+        }
+
+        if (hi <= range_hi) {
+            const unsigned w = pos[static_cast<unsigned>(hi)];
+            if (w != u && w != v) {
+                const unsigned c1 = fmax[w] > lbl_v ? fmax[w] - lbl_v : lbl_v - fmax[w];
+                if (c1 < bestCost) {
+                    const unsigned c2 = lbl_v > fmin[w] ? lbl_v - fmin[w] : fmin[w] - lbl_v;
+                    if (c2 < bestCost) {
+                        const unsigned cost = c1 > c2 ? c1 : c2;
+                        if (cost < bestCost) {
+                            bestCost = cost;
+                            bestW    = static_cast<int>(w);
+                            if (bestCost == 0) return bestW;
+                        }
+                    }
+                }
+            }
+            ++hi;
+        }
+    }
+
+    return bestW;
+}
+
+// actual Shake-1
+void shake1(
+    std::vector<unsigned>& f,
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned n,
+    unsigned k,
+    std::mt19937& rng,
+    VNSTimings& T
+)
+{
+    if (n == 0 || k == 0) return;
+
+    T.shake1Calls++;
+
+    // Pre-allocate all scratch buffers
+    std::vector<unsigned> K;
+    std::vector<unsigned> B_local(n, 0);
+    std::vector<unsigned> sortedVals(n);
+    std::vector<unsigned> fmin(n, 0);
+    std::vector<unsigned> fmax(n, 0);
+    std::vector<unsigned> maxCandidates;
+    unsigned Bprime = 0;
+
+    // pos[label] = vertex; updated O(1) after each swap
+    std::vector<unsigned> pos(n);
+    for (unsigned v = 0; v < n; ++v)
+        pos[f[v]] = v;
+
+    // --- Full O(m) pass once before the loop ---
+    {
+        VTIME_START(sd);
+        computeShakeData(f, ptr, ind, n, k, K, B_local, sortedVals, fmin, fmax, Bprime);
+        VTIME_STOP(T.s1_shakeData, sd);
+    }
+
+    // cnt[b] = number of vertices with B_local[v] == b; enables O(1) updates
+    std::vector<unsigned> cnt(n, 0);
+    for (unsigned v = 0; v < n; ++v)
+        cnt[B_local[v]]++;
+
+    // globalMax: highest b with cnt[b] > 0
+    unsigned globalMax = 0;
+    for (unsigned b = n; b-- > 0; )
+        if (cnt[b] > 0) { globalMax = b; break; }
+
+    // inK[x]=1 iff x is currently in K; posInK[x]=its index in K (valid when inK[x]=1).
+    // Maintained incrementally so K can be updated in O(|affected|) when Bprime is stable.
+    std::vector<char> inK(n, 0);
+    std::vector<unsigned> posInK(n, 0);
+    for (unsigned i = 0; i < static_cast<unsigned>(K.size()); ++i) {
+        inK[K[i]] = 1;
+        posInK[K[i]] = i;
+    }
+
+    // visited[]: deduplicates the affected set; reset only for touched entries
+    std::vector<char> visited(n, 0);
+    std::vector<unsigned> affected;
+    affected.reserve(256);
+
+    // processVertex: rescan x's neighbors to update B_local/fmin/fmax and cnt
+    auto processVertex = [&](unsigned x) {
+        if (visited[x]) return;
+        visited[x] = 1;
+        affected.push_back(x);
+
+        const unsigned old_b = B_local[x];
+        const unsigned fx    = f[x];
+        unsigned localMax = 0;
+        bool first = true;
+        unsigned mn = fx, mx = fx;
+
+        for (unsigned p = ptr[x]; p < ptr[x + 1]; ++p) {
+            unsigned nb = ind[p];
+            if (nb == x) continue;
+            const unsigned fnb  = f[nb];
+            const unsigned diff = (fx > fnb) ? (fx - fnb) : (fnb - fx);
+            if (diff > localMax) localMax = diff;
+            if (first) { mn = fnb; mx = fnb; first = false; }
+            else { if (fnb < mn) mn = fnb; if (fnb > mx) mx = fnb; }
+        }
+
+        B_local[x] = localMax;
+        fmin[x]    = mn;
+        fmax[x]    = mx;
+
+        if (old_b != localMax) {
+            cnt[old_b]--;
+            cnt[localMax]++;
+        }
+    };
+
+    for (unsigned iter = 0; iter < k; ++iter) {
+
+        if (K.empty() || Bprime == 0) break;
+
+        // --- 1. Pick u uniformly at random from K ---
+        std::uniform_int_distribution<unsigned> distU(0, static_cast<unsigned>(K.size() - 1));
+        unsigned u = K[distU(rng)];
+
+        // --- 2. Find v: worst neighbor of u ---
+        unsigned lbl_u = f[u];
+        maxCandidates.clear();
+        unsigned maxDiffUV = 0;
+
+        for (unsigned p = ptr[u]; p < ptr[u + 1]; ++p) {
+            unsigned cand = ind[p];
+            if (cand == u) continue;
+            unsigned diff = (f[cand] > lbl_u) ? (f[cand] - lbl_u) : (lbl_u - f[cand]);
+            if (diff > maxDiffUV) {
+                maxDiffUV = diff;
+                maxCandidates.clear();
+                maxCandidates.push_back(cand);
+            } else if (diff == maxDiffUV) {
+                maxCandidates.push_back(cand);
+            }
+        }
+
+        if (maxCandidates.empty() || maxDiffUV == 0) continue;
+
+        unsigned v;
+        if (maxCandidates.size() == 1) {
+            v = maxCandidates[0];
+        } else {
+            std::uniform_int_distribution<unsigned> distV(0, static_cast<unsigned>(maxCandidates.size() - 1));
+            v = maxCandidates[distV(rng)];
+        }
+
+        // --- 3. Choose w ---
+        int bestW;
+        {
+            VTIME_START(sw);
+            bestW = selectW(u, v, f, fmin, fmax, pos);
+            VTIME_STOP(T.s1_selectW, sw);
+        }
+        if (bestW < 0) continue; // no swap — data still valid for next iteration
+
+        // --- 4. Swap labels of v and w; update pos ---
+        unsigned w = static_cast<unsigned>(bestW);
+        std::swap(f[v], f[w]);
+        pos[f[v]] = v;
+        pos[f[w]] = w;
+
+        // --- 5. Incremental update of B_local/fmin/fmax/cnt/Bprime/K ---
+        // Only vertices in {v,w} ∪ N(v) ∪ N(w) have changed local data.
+        // O(Σ deg(x) for x in affected) + O(n) for K rebuild — replaces O(m) full pass.
+        {
+            VTIME_START(iu);
+
+            // Rescan v, neighbors of v, w, neighbors of w (deduplicated via visited[])
+            processVertex(v);
+            for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+                unsigned nb = ind[p];
+                if (nb != v) processVertex(nb);
+            }
+            processVertex(w);
+            for (unsigned p = ptr[w]; p < ptr[w + 1]; ++p) {
+                unsigned nb = ind[p];
+                if (nb != w) processVertex(nb);
+            }
+
+            // Reset visited flags; keep `affected` alive until after K update
+            for (unsigned x : affected) visited[x] = 0;
+
+            // Update globalMax: scan down until a non-zero cnt bucket
+            while (globalMax > 0 && cnt[globalMax] == 0) --globalMax;
+
+            // Recompute Bprime: k-th largest B_local (scan cnt from top)
+            const unsigned oldBprime = Bprime;
+            if (globalMax == 0) {
+                Bprime = 0;
+            } else {
+                const unsigned idx = std::min<unsigned>(k - 1, n - 1);
+                unsigned cumsum = 0;
+                Bprime = 0;
+                for (unsigned b = globalMax; ; --b) {
+                    cumsum += cnt[b];
+                    if (cumsum > idx) { Bprime = b; break; }
+                    if (b == 0) break;
+                }
+            }
+
+            // Update K
+            if (Bprime == oldBprime) {
+                // Bprime unchanged: only vertices in `affected` can have changed
+                // membership. Update K in O(|affected|) using inK/posInK.
+                for (unsigned x : affected) {
+                    const bool shouldBeIn = (B_local[x] >= Bprime);
+                    if (shouldBeIn && !inK[x]) {
+                        posInK[x] = static_cast<unsigned>(K.size());
+                        K.push_back(x);
+                        inK[x] = 1;
+                    } else if (!shouldBeIn && inK[x]) {
+                        // O(1) swap-erase
+                        const unsigned pos_x = posInK[x];
+                        const unsigned last  = K.back();
+                        K[pos_x]    = last;
+                        posInK[last] = pos_x;
+                        K.pop_back();
+                        inK[x] = 0;
+                    }
+                }
+            } else {
+                // Bprime changed: full O(n) rebuild required
+                K.clear();
+                std::fill(inK.begin(), inK.end(), 0);
+                for (unsigned x = 0; x < n; ++x) {
+                    if (B_local[x] >= Bprime) {
+                        posInK[x] = static_cast<unsigned>(K.size());
+                        K.push_back(x);
+                        inK[x] = 1;
+                    }
+                }
+            }
+
+            affected.clear();
+
+            VTIME_STOP(T.s1_incrUpdate, iu);
+        }
+    }
+}
+
+// `Shake` step 2: randomly rotates an interval repeated k times
+void shake2(
+    std::vector<unsigned>& f,
+    unsigned Bf,
+    unsigned k,
+    std::mt19937& rng,
+    VNSTimings& T
+) {
+    T.shake2Calls++;
+    if (k==0) return;
+    const unsigned n = f.size();
+    if (n < 3) return;
+
+    // Build inverse permutation p[label] = vertex
+    std::vector<unsigned> p(n);
+    for (unsigned v = 0; v < n; ++v)
+        p[f[v]] = v;
+    for (unsigned iter = 0; iter < k; ++iter)
+    {
+        unsigned beginning = std::uniform_int_distribution<unsigned>(0, n - 1)(rng);
+
+        // guard against too small Bf so upper bound >= 2
+        unsigned maxLen = (Bf > 3 ? std::min(20u, Bf / 2) : 2u);
+        if (maxLen < 2) continue;
+
+        unsigned ending = beginning + std::uniform_int_distribution<unsigned>(2, maxLen)(rng);
+
+        if (ending > n - 1)
+            ending = n - 1;
+
+        if (ending <= beginning + 1)
+            continue; // skip this iteration
+
+        unsigned innerLen = ending - beginning - 1;
+        if (innerLen == 0) continue;
+
+        unsigned middle = std::uniform_int_distribution<unsigned>(1, innerLen)(rng);
+
+        // Rotate labels in-place and do partial pos update
+        for (unsigned j = beginning; j <= ending; ++j) {
+            unsigned vertex = p[j];
+            if (j >= beginning + middle) {
+                f[vertex] = j - middle;
+            } else {
+                f[vertex] = j + ending - beginning - middle + 1;
+            }
+        }
+
+        // OPT: partial pos update — only fix entries for affected range
+        for (unsigned j = beginning; j <= ending; ++j) {
+            unsigned vertex = p[j];       // vertex that had label j
+            p[f[vertex]] = vertex;        // update its new position
+        }
+    }
+}
+
+// SHAKE PROPER
+void shake(
+    std::vector<unsigned>& f,
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned n,
+    unsigned k,
+    unsigned k_min,
+    unsigned k_step,
+    unsigned kprime_max,
+    unsigned Bf,
+    std::mt19937& rng,
+    VNSTimings& T
+) {
+    if (k <= kprime_max) {
+        shake1(f, ptr, ind, n, k, rng, T);
+    } else {
+        unsigned kprime = (k - k_min) / k_step;
+        shake2(f, Bf, kprime, rng, T);
+    }
+}
+
+// Move or not function: decide if fPrime is "better" than f
+bool Move(const std::vector<unsigned>& f,
+          const std::vector<unsigned>& fPrime,
+          const unsigned* ptr,
+          const unsigned* ind,
+          unsigned n,
+          unsigned alpha,
+          const unsigned& Bf,
+          const unsigned& Bfp)
+{
+    if (Bfp < Bf) return true;
+
+    if (Bfp == Bf) {
+
+        const unsigned rho = hammingDistance(f, fPrime);
+        if (rho > alpha) return true;
+
+        std::vector<char> isCriticalF(n,0);
+        std::vector<char> isCriticalFprime(n,0);
+        const unsigned VCf  = countCriticalVertices(f,      ptr, ind, n, Bf, isCriticalF);
+        const unsigned VCfp = countCriticalVertices(fPrime, ptr, ind, n, Bfp, isCriticalFprime);
+
+        if (VCfp < VCf) return true;
+    }
+
+    return false;
+}
+
+
+void computeNPrime(
+    const std::vector<unsigned>& f,
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned n,
+    unsigned v,
+    std::vector<unsigned>& nprime
+) {
+    nprime.clear();
+    if (n == 0 || v >= n) return;
+
+    unsigned mn = f[v], mx = f[v];
+    bool first = true;
+    for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+        unsigned u = ind[p];
+        if (u == v) continue;
+        if (first) { mn = f[u]; mx = f[u]; first = false; }
+        else {
+            if (f[u] < mn) mn = f[u];
+            if (f[u] > mx) mx = f[u];
+        }
+    }
+
+    unsigned mid = (mn + mx) / 2;
+    unsigned dv = (mid > f[v]) ? (mid - f[v]) : (f[v] - mid);
+
+    for (unsigned p = ptr[v]; p < ptr[v + 1]; ++p) {
+        unsigned u = ind[p];
+        if (u == v) continue;
+        unsigned du = (mid > f[u]) ? (mid - f[u]) : (f[u] - mid);
+        if (du < dv) {
+            nprime.push_back(u);
+        }
+    }
+
+    std::sort(nprime.begin(), nprime.end(),
+          [&](unsigned a, unsigned b) {
+              unsigned da = (mid > f[a]) ? (mid - f[a]) : (f[a] - mid);
+              unsigned db = (mid > f[b]) ? (mid - f[b]) : (f[b] - mid);
+              return da < db;
+          });
+}
+
+
+void LocalSearchIHC(std::vector<unsigned>& f, unsigned n, unsigned& Bf,
+                    const unsigned* ptr, const unsigned* ind,
+                    std::vector<unsigned>& B_local,
+                    VNSTimings& T)
+{
+    T.ihcCalls++;
+    bool canImprove = true;
+    std::vector<char> criticalVertices;
+    findCriticalVertices(f, ptr, ind, n, Bf, criticalVertices);
+    unsigned criticalCount = 0;
+    for (char c : criticalVertices) criticalCount += static_cast<unsigned>(c != 0);
+    std::vector<unsigned> nPrimeV;  // pre-allocate outside loops
+
+    // cnt[b] = number of vertices with B_local[v] == b; lets us find max(B_local) without
+    // a full O(m) edge scan — same technique as shake1's incremental update.
+    std::vector<unsigned> cnt(n, 0);
+    for (unsigned w = 0; w < n; ++w)
+        cnt[B_local[w]]++;
+    unsigned globalBW = Bf;  // tracks max(B_local), equals Bf initially
+
+    while (canImprove) {
+        canImprove = false;
+        T.ihcOuterPasses++;
+        for (unsigned v = 0; v < n; ++v)
+        {
+            if (criticalVertices[v] != 1) continue;
+
+            {
+                VTIME_START(cnp);
+                computeNPrime(f, ptr, ind, n, v, nPrimeV);
+                VTIME_STOP(T.ihc_computeNP, cnp);
+            }
+            if (nPrimeV.empty()) continue;
+
+            for (unsigned i = 0; i < nPrimeV.size(); ++i)
+            {
+                T.ihcSwapAttempts++;
+                unsigned u = nPrimeV[i];
+
+                // tentatively swap in-place
+                std::swap(f[v], f[u]);
+
+                unsigned newBW_v, newBW_u;
+                {
+                    VTIME_START(lbw);
+                    newBW_v = localBandwidth(f, ptr, ind, v);
+                    VTIME_STOP(T.ihc_localBW, lbw);
+                }
+                if (newBW_v > Bf) { std::swap(f[v], f[u]); continue; }
+
+                {
+                    VTIME_START(lbw2);
+                    newBW_u = localBandwidth(f, ptr, ind, u);
+                    VTIME_STOP(T.ihc_localBW, lbw2);
+                }
+                if (newBW_u > Bf) { std::swap(f[v], f[u]); continue; }
+
+                // Theorem 1: compute C' values
+                // C'(x) = 2 if local BW > Bf (already rejected above)
+                // C'(x) = 1 if local BW == Bf
+                // C'(x) = 0 if local BW < Bf
+                unsigned Cprime_v = (newBW_v == Bf) ? 1 : 0;
+                unsigned Cprime_u = (newBW_u == Bf) ? 1 : 0;
+                unsigned C_v = static_cast<unsigned char>(criticalVertices[v]);
+                unsigned C_u = static_cast<unsigned char>(criticalVertices[u]);
+
+                if (Cprime_u <= C_u &&
+                    Cprime_v <= C_v &&
+                    Cprime_u + Cprime_v < C_u + C_v)
+                {
+                    T.ihcSwapAccepted++;
+                    // accepted — update Bf and critical vertices
+
+                    // update B_local for affected vertices; keep cnt in sync
+                    cnt[B_local[v]]--; B_local[v] = newBW_v; cnt[newBW_v]++;
+                    cnt[B_local[u]]--; B_local[u] = newBW_u; cnt[newBW_u]++;
+                    for (unsigned p = ptr[v]; p < ptr[v+1]; ++p) {
+                        unsigned w = ind[p];
+                        if (w != v) {
+                            VTIME_START(lbwN);
+                            unsigned newB = localBandwidth(f, ptr, ind, w);
+                            VTIME_STOP(T.ihc_localBW, lbwN);
+                            if (B_local[w] != newB) { cnt[B_local[w]]--; cnt[newB]++; }
+                            B_local[w] = newB;
+                        }
+                    }
+                    for (unsigned p = ptr[u]; p < ptr[u+1]; ++p) {
+                        unsigned w = ind[p];
+                        if (w != u) {
+                            VTIME_START(lbwN2);
+                            unsigned newB = localBandwidth(f, ptr, ind, w);
+                            VTIME_STOP(T.ihc_localBW, lbwN2);
+                            if (B_local[w] != newB) { cnt[B_local[w]]--; cnt[newB]++; }
+                            B_local[w] = newB;
+                        }
+                    }
+                    // advance globalBW down to the new max(B_local)
+                    while (globalBW > 0 && cnt[globalBW] == 0) --globalBW;
+
+                    // check if bandwidth actually decreased
+                    if (Cprime_v == 0 && Cprime_u == 0 && criticalCount == 2) {
+                        T.ihcFullBWCalls++;
+                        VTIME_START(fbw);
+                        // globalBW = max(B_local) maintained by cnt — no O(m) edge scan needed
+                        unsigned newBf = globalBW;
+                        VTIME_STOP(T.ihc_fullBW, fbw);
+                        if (newBf < Bf) {
+                            Bf = newBf;  // globalBW already equals newBf from the scan above
+                            // Bf decreased: vertices far from v,u may be newly critical.
+                            // Rebuild criticalVertices and criticalCount from stored B_local
+                            // (O(n), no edge traversal — B_local is correct for all vertices).
+                            criticalCount = 0;
+                            for (unsigned w = 0; w < n; ++w) {
+                                criticalVertices[w] = (B_local[w] == Bf) ? 1 : 0;
+                                criticalCount += criticalVertices[w];
+                            }
+                            canImprove = true;
+                            break;
+                        }
+                    }
+
+                    // update criticalVertices and criticalCount for v, u, and their neighbors
+                    auto updateCrit = [&](unsigned w) {
+                        char newCrit = (B_local[w] == Bf) ? 1 : 0;
+                        if (newCrit != criticalVertices[w]) {
+                            criticalCount += newCrit - criticalVertices[w];
+                            criticalVertices[w] = newCrit;
+                        }
+                    };
+                    for (unsigned w : {v, u}) {
+                        updateCrit(w);
+                        for (unsigned p = ptr[w]; p < ptr[w+1]; ++p) {
+                            unsigned x = ind[p];
+                            if (x == w) continue;
+                            updateCrit(x);
+                        }
+                    }
+                    canImprove = true;
+                    break;
+                }
+                // rejected. swap back
+                std::swap(f[v], f[u]);
+            }
+        }
+    }
+    Bf = globalBW;
+}
+
+
+// VNS-Band main loop
+void vnsBand(
+    const unsigned* ptr,
+    const unsigned* ind,
+    unsigned n,
+    unsigned t_max,
+    unsigned alpha,
+    std::vector<unsigned>& bestF,
+    std::mt19937& rng,
+    unsigned long long& iCount,
+    std::chrono::steady_clock::time_point deadline
+) {
+    if (n == 0) return;
+
+    VNSTimings T;
+    auto wallStart = std::chrono::steady_clock::now();
+
+    // best bandwidth seen so far: B*
+    unsigned B_star = std::numeric_limits<unsigned>::max();
+
+    const unsigned I_MAX = (K_MAX - KMIN) / KSTEP;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        for (unsigned t = 0; t < t_max; ++t) {
+            T.tRestarts++;
+
+            std::vector<unsigned> f;
+            {
+                VTIME_START(init);
+                f = initialVNSBandLabeling(ptr, ind, n, rng);
+                VTIME_STOP(T.initLabeling, init);
+            }
+
+            std::vector<unsigned> B_local(n, 0);
+            unsigned Bf;
+            {
+                VTIME_START(bw0);
+                Bf = computeLocalAndGlobalBandwidth(f, ptr, ind, n, B_local);
+                VTIME_STOP(T.computeBW, bw0);
+                T.computeBWCalls++;
+            }
+
+            {
+                VTIME_START(ihc0);
+                LocalSearchIHC(f, n, Bf, ptr, ind, B_local, T);
+                VTIME_STOP(T.localSearch, ihc0);
+            }
+
+            unsigned i = 0;
+            unsigned k = KMIN;
+
+            // OPT: pre-allocate fPrime and Bf_prime_local outside the inner loop
+            // to avoid repeated O(n) heap allocations per iteration.
+            std::vector<unsigned> fPrime(n);
+            std::vector<unsigned> Bf_prime_local(n);
+
+            while (i <= I_MAX && std::chrono::steady_clock::now() < deadline) {
+                T.vnsTotalIter++;
+                iCount++;
+                if (iCount % 100 == 0)
+                    std::cout << "VNS V3 iteration i= " << iCount << std::endl;
+
+                // reuse pre-allocated buffers
+                fPrime.assign(f.begin(), f.end());
+                {
+                    VTIME_START(shk);
+                    shake(fPrime, ptr, ind, n, k, KMIN, KSTEP, KPRIME_MAX, Bf, rng, T);
+                    VTIME_STOP(T.shakeTotal, shk);
+                }
+
+                unsigned Bf_prime;
+                {
+                    VTIME_START(bw1);
+                    Bf_prime = computeLocalAndGlobalBandwidth(fPrime, ptr, ind, n, Bf_prime_local);
+                    VTIME_STOP(T.computeBW, bw1);
+                    T.computeBWCalls++;
+                }
+
+                {
+                    VTIME_START(ihc1);
+                    LocalSearchIHC(fPrime, n, Bf_prime, ptr, ind, Bf_prime_local, T);
+                    VTIME_STOP(T.localSearch, ihc1);
+                }
+
+                bool moved;
+                {
+                    VTIME_START(mv);
+                    moved = Move(f, fPrime, ptr, ind, n, alpha, Bf, Bf_prime);
+                    VTIME_STOP(T.moveCheck, mv);
+                }
+
+                if (moved) {
+                    T.moveAccepted++;
+                    f.swap(fPrime);
+                    Bf = Bf_prime;
+                    k = KMIN;
+                    i = 0;
+                } else {
+                    T.moveRejected++;
+                    k += KSTEP;
+                    ++i;
+                }
+            }
+
+            if (Bf < B_star) {
+                B_star = Bf;
+                bestF = f;
+            }
+        }
+    }
+
+    T.print(wallStart);
+}
+
+
+void VNSBandOrdering::orderingFunction() {
+
+    const SparseMatrix& M = this->getMatrix();
+    const unsigned nr = M.getRowCount();
+    const unsigned nc = M.getColCount();
+
+    if (nr == 0) return;
+
+    const unsigned* ptrRaw = M.getPtr();
+    const unsigned* indRaw = M.getInd();
+
+    std::vector<unsigned> bestF;
+
+    // Later user input
+    const unsigned T_MAX_ITERS = 20;
+    const unsigned ALPHA       = 10;
+    thread_local std::mt19937 rng(std::random_device{}());
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::minutes(3);
+
+    unsigned long long iCount = 0;
+
+    vnsBand(ptrRaw, indRaw, nr, T_MAX_ITERS, ALPHA, bestF, rng, iCount, deadline);
+
+    rowIPermutation = new vType[nr];
+    for (unsigned v = 0; v < nr; ++v) {
+        rowIPermutation[v] = bestF[v];
+    }
+
+    colIPermutation = new vType[nc];
+    if (nr == nc) {
+        for (unsigned v = 0; v < nc; ++v)
+            colIPermutation[v] = rowIPermutation[v];
+    } else {
+        for (unsigned j = 0; j < nc; ++j)
+            colIPermutation[j] = j;
+    }
+}


### PR DESCRIPTION
 Adds matrix ordering implementations developed over the past year:
  
  - **GPS** (Gibbs-Poole-Stockmeyer) — V2 and V3AGENTIC variants
  - **RBFS-GL** — Reverse BFS with George Liu rule
  - **Sloan** envelope ordering + **Sloan-MGPS** hybrid
  - **VNSBand** (Variable Neighborhood Search) — V3 and V3+RCM variants
  
  Also includes:
  - `SparseVizEngine` updates to register the new orderings (and to recognize DRSA, RCMPP, Spectral, which are referenced but not yet committed in this PR).
  - `AMDOrdering.cpp`: `extern "C"` wrapper around `amd.h` for proper C++ linkage.
  - `CMakeLists.txt`: wires up the new sources/headers; replaces hard-coded `/home/delbek/…` paths with `${PROJECT_SOURCE_DIR}/lib` for portability. The CMakeLists also
   references DRSA / RCMPP / Spectral filenames; those source files are intentionally not in this PR and will be added separately.