### PR TITLE
Added DRSA and RCM++ ordering files.

### DIFF
--- a/include/Matrix/Orderings/DRSAOrdering.h
+++ b/include/Matrix/Orderings/DRSAOrdering.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "MatrixOrdering.h"
+#include <vector>
+#include <random>
+
+class DRSAOrdering : public MatrixOrdering
+{
+public:
+    DRSAOrdering(SparseMatrix& matrix, std::string orderingName, std::string orderingParameters);
+    ~DRSAOrdering() override = default;
+
+protected:
+    void orderingFunction() override;
+
+private:
+    // Simulated Annealing Parameters tuned via the paper
+    double m_T0;
+    double m_Alpha;
+    double m_Tf;
+    double m_L0;
+    double m_Lf;
+    
+    std::mt19937 m_Rng;
+};

--- a/include/Matrix/Orderings/RCMPPOrdering.h
+++ b/include/Matrix/Orderings/RCMPPOrdering.h
@@ -1,0 +1,61 @@
+//
+// Created by Kamer Kaya on 22.12.2023. (Modified by Mehmet Berkay Catak on 09.11.2025)
+//
+
+#ifndef SPARSEVIZ_RCMPPORDERING_H
+#define SPARSEVIZ_RCMPPORDERING_H
+
+#include "MatrixOrdering.h"
+#include "SparseMatrix.h"
+#include <vector>
+#include <algorithm>
+#include "config.h"
+#include "helpers.h"
+
+class RCMPPOrdering: public MatrixOrdering
+{
+public:
+    RCMPPOrdering(SparseMatrix& matrix, std::string orderingName, std::string orderingParameters) :
+    MatrixOrdering(matrix, orderingName, false, false), m_SortingCriteria("DEG"), m_RootSelection(true) {
+
+        if(orderingParameters != "") {
+            std::vector<std::string> parameters = split(orderingParameters, '/');
+
+            if (parameters.size() > 0) {
+                m_SortingCriteria = parameters[0];
+            } 
+            if (parameters.size() > 1) {
+                if(parameters[1] == "FALSE") {
+                    m_RootSelection = false;
+                }
+            }
+        }
+    }
+
+	virtual ~RCMPPOrdering();
+private:
+    std::string m_SortingCriteria; 
+    bool m_RootSelection; 
+
+    static constexpr unsigned NUM_SORT_BUCKETS     = 16;
+    static constexpr unsigned SMALL_SORT_THRESHOLD = 6;
+
+    virtual void orderingFunction() override;
+    
+    // RCM++ (BNF) Helper Functions
+    void runBFS (    unsigned start_node, unsigned* queue,
+                       int* level, unsigned& ccsize, int& final_level);  
+    unsigned findMinDegreeNodeOnDeepestLevel (    unsigned* queue, int* level, unsigned ccsize, int final_level); 
+    double calculateWidth (    unsigned* queue, int* level, unsigned ccsize, int final_level); 
+    void resetLevels(unsigned int* queue, int* level, unsigned int ccsize);
+
+    void sortNeighborsBuckets(unsigned* queue, unsigned start_v, unsigned qe, double* sort_values);
+    
+    // Original RCM function
+    void rcm (  unsigned& root, unsigned* queue,    
+                double* sort_values,
+                bool* is_permuted);
+    
+};
+
+#endif //SPARSEVIZ_RCMPPORDERING_H

--- a/src/Matrix/Orderings/DRSAOrdering.cpp
+++ b/src/Matrix/Orderings/DRSAOrdering.cpp
@@ -1,0 +1,264 @@
+#include "DRSAOrdering.h"
+#include <cmath>
+#include <algorithm>
+#include <iostream>
+
+DRSAOrdering::DRSAOrdering(SparseMatrix& matrix, std::string orderingName, std::string orderingParameters)
+    : MatrixOrdering(matrix, orderingName, false, false, 500) // rectangularSupport=false, patternUnsymmetricSupport=false
+{
+    // Parameters determined via the full factorial tuning in the paper
+    m_T0 = 1000.0;
+    m_Tf = 1e-7;
+    m_L0 = 40.0;
+    
+    std::random_device rd;
+    m_Rng = std::mt19937(rd());
+}
+
+
+void DRSAOrdering::orderingFunction()
+{
+    vType n = getMatrix().getRowCount();
+    vType m = std::max((vType)1, getMatrix().getNNZCount() / 2);
+
+    m_Alpha = (n < 5000) ? 0.97 : 0.99;
+    m_Lf = std::min(10.0 * n * m, 500.0 * n);
+    
+    double r_sa = (std::log(m_Tf) - std::log(m_T0)) / std::log(m_Alpha);
+    double gamma = std::exp((std::log(m_Lf) - std::log(m_L0)) / r_sa);
+
+    double T = m_T0;
+    double L = m_L0;
+
+    std::vector<vType> current_pi(n);
+    std::vector<vType> current_rho(n);
+    for (vType i = 0; i < n; ++i) {
+        current_pi[i] = i;
+        current_rho[i] = i;
+    }
+    std::shuffle(current_pi.begin(), current_pi.end(), m_Rng);
+    for (vType i = 0; i < n; ++i) {
+        current_rho[current_pi[i]] = i;
+    }
+
+    vType beta = 0;
+    std::vector<vType> d(n + 1, 0);
+    const vType* ptr = getMatrix().getPtr();
+    const vType* ind = getMatrix().getInd();
+
+    double current_delta = 0.0;
+
+    // Initial calculation
+    for (vType u = 0; u < n; ++u) {
+        for (vType j = ptr[u]; j < ptr[u + 1]; ++j) {
+            vType v = ind[j];
+            if (u < v) {
+                vType diff = std::abs(static_cast<long long>(current_pi[u]) - current_pi[v]);
+                if (diff > beta) beta = diff;
+                d[diff]++;
+            }
+        }
+    }
+
+    for (vType i = 0; i <= beta; ++i) {
+        current_delta += static_cast<double>(d[i]) / (n - i + 1);
+    }
+
+    std::vector<vType> w_pi = current_pi;
+    double f_w = static_cast<double>(beta) + current_delta;
+    double f_x = f_w;
+
+    std::uniform_real_distribution<double> p_dist(0.0, 1.0);
+    std::uniform_int_distribution<vType> dist_n(0, n - 1);
+
+    std::vector<vType> changed_vertices;
+    changed_vertices.reserve(10);
+
+    // Fast byte-level boolean array to replace sorting/unique operations
+    std::vector<char> in_changed(n, 0);
+
+    int stay_count = 0;
+    const int MAX_STAYS = 3;
+
+    while (T > m_Tf) {
+        bool improvement = false;
+        int L_int = static_cast<int>(std::min(L, static_cast<double>(5 * n)));
+
+        for (int step = 0; step < L_int; ++step) {
+
+            double p = p_dist(m_Rng);
+            int op = 0;
+            vType u = 0, v = 0;
+            int rot_i = 0, rot_j = 0;
+
+            if (p <= 0.6) {
+                op = 0;
+                u = dist_n(m_Rng); v = dist_n(m_Rng);
+                if (u != v) {
+                    changed_vertices.push_back(u);
+                    changed_vertices.push_back(v);
+                }
+            } else if (p <= 0.8) {
+                op = 1;
+                u = dist_n(m_Rng);
+                vType degree = ptr[u + 1] - ptr[u];
+                if (degree > 0) {
+                    std::uniform_int_distribution<vType> nbr_dist(ptr[u], ptr[u + 1] - 1);
+                    v = ind[nbr_dist(m_Rng)];
+                    if (u != v) {
+                        changed_vertices.push_back(u);
+                        changed_vertices.push_back(v);
+                    }
+                }
+            } else {
+                op = 2;
+                int max_r = std::min(5, static_cast<int>(n) - 1);
+                if (max_r >= 1) {
+                    std::uniform_int_distribution<int> dist_r(1, max_r);
+                    int r = dist_r(m_Rng);
+                    std::uniform_int_distribution<int> dist_i(0, static_cast<int>(n) - 1 - r);
+                    rot_i = dist_i(m_Rng);
+                    rot_j = rot_i + r;
+                    for (int k = rot_i; k <= rot_j; ++k) {
+                        changed_vertices.push_back(current_rho[k]);
+                    }
+                }
+            }
+
+            if (changed_vertices.empty()) continue;
+
+            // Mark vertices for instant O(1) existence checks
+            for (vType v_c : changed_vertices) in_changed[v_c] = 1;
+
+            // 1. Instantly subtract old edge distances
+            for (vType node : changed_vertices) {
+                for (vType j = ptr[node]; j < ptr[node + 1]; ++j) {
+                    vType nbr = ind[j];
+                    // Skip if the neighbor is ALSO in changed_vertices AND we already processed it
+                    if (in_changed[nbr] && node > nbr) continue;
+
+                    vType diff = std::abs((long long)current_pi[node] - current_pi[nbr]);
+                    d[diff]--;
+                    current_delta -= 1.0 / (n - diff + 1);
+                }
+            }
+
+            // 2. Swap array layouts
+            if (op == 0 || op == 1) {
+                std::swap(current_pi[u], current_pi[v]);
+                current_rho[current_pi[u]] = u;
+                current_rho[current_pi[v]] = v;
+            } else {
+                vType temp_vertex = current_rho[rot_i];
+                for (int k = rot_i; k < rot_j; ++k) {
+                    current_rho[k] = current_rho[k + 1];
+                    current_pi[current_rho[k]] = k;
+                }
+                current_rho[rot_j] = temp_vertex;
+                current_pi[temp_vertex] = rot_j;
+            }
+
+            // 3. Instantly add new edge distances
+            vType max_new_diff = 0;
+            for (vType node : changed_vertices) {
+                for (vType j = ptr[node]; j < ptr[node + 1]; ++j) {
+                    vType nbr = ind[j];
+                    if (in_changed[nbr] && node > nbr) continue;
+
+                    vType diff = std::abs((long long)current_pi[node] - current_pi[nbr]);
+                    d[diff]++;
+                    current_delta += 1.0 / (n - diff + 1);
+                    if (diff > max_new_diff) max_new_diff = diff;
+                }
+            }
+
+            vType old_beta = beta;
+            if (max_new_diff > beta) {
+                beta = max_new_diff;
+            } else {
+                while (beta > 0 && d[beta] == 0) {
+                    beta--;
+                }
+            }
+
+            // O(1) Evaluation!
+            double f_y = static_cast<double>(beta) + current_delta;
+
+            // 4. Check Acceptance
+            if (f_y < f_x || p_dist(m_Rng) < std::exp(-(f_y - f_x) / T)) {
+                f_x = f_y;
+                if (f_x < f_w) {
+                    w_pi = current_pi;
+                    f_w = f_x;
+                    improvement = true;
+                }
+            } else {
+                // 5. Revert Changes (Subtract new distances)
+                for (vType node : changed_vertices) {
+                    for (vType j = ptr[node]; j < ptr[node + 1]; ++j) {
+                        vType nbr = ind[j];
+                        if (in_changed[nbr] && node > nbr) continue;
+                        vType diff = std::abs((long long)current_pi[node] - current_pi[nbr]);
+                        d[diff]--;
+                        current_delta -= 1.0 / (n - diff + 1);
+                    }
+                }
+
+                // Un-swap layouts
+                if (op == 0 || op == 1) {
+                    std::swap(current_pi[u], current_pi[v]);
+                    current_rho[current_pi[u]] = u;
+                    current_rho[current_pi[v]] = v;
+                } else {
+                    vType temp_vertex = current_rho[rot_j];
+                    for (int k = rot_j; k > rot_i; --k) {
+                        current_rho[k] = current_rho[k - 1];
+                        current_pi[current_rho[k]] = k;
+                    }
+                    current_rho[rot_i] = temp_vertex;
+                    current_pi[temp_vertex] = rot_i;
+                }
+
+                // Re-add old distances
+                for (vType node : changed_vertices) {
+                    for (vType j = ptr[node]; j < ptr[node + 1]; ++j) {
+                        vType nbr = ind[j];
+                        if (in_changed[nbr] && node > nbr) continue;
+                        vType diff = std::abs((long long)current_pi[node] - current_pi[nbr]);
+                        d[diff]++;
+                        current_delta += 1.0 / (n - diff + 1);
+                    }
+                }
+                beta = old_beta;
+            }
+
+            // Unmark tracking array for the next step
+            for (vType v_c : changed_vertices) in_changed[v_c] = 0;
+            changed_vertices.clear();
+
+            // Prevent floating point drift accumulating over millions of loop iterations
+            if (step > 0 && step % 10000 == 0) {
+                double exact_delta = 0.0;
+                for (vType i = 0; i <= beta; ++i) {
+                    exact_delta += static_cast<double>(d[i]) / (n - i + 1);
+                }
+                current_delta = exact_delta;
+            }
+        }
+
+        if (!improvement || stay_count >= MAX_STAYS) {
+            T *= m_Alpha;
+            L = std::min(L * gamma, m_Lf);
+            stay_count = 0;
+        } else {
+            stay_count++;
+        }
+    }
+
+    rowIPermutation = new vType[n];
+    colIPermutation = new vType[n];
+    for (vType i = 0; i < n; ++i) {
+        rowIPermutation[i] = w_pi[i];
+        colIPermutation[i] = w_pi[i];
+    }
+}

--- a/src/Matrix/Orderings/RCMPPOrdering.cpp
+++ b/src/Matrix/Orderings/RCMPPOrdering.cpp
@@ -1,0 +1,376 @@
+//                                                                                                                                                                                                          
+// Created on 22 September 2023 (Modified for RCM++/BNF on 9 November 2025)                                                                                                                                                                
+//                                                                                                                                                                                                          
+
+#include "RCMPPOrdering.h"
+#include <vector>
+#include <limits> // Required for std::numeric_limits<double>::max()
+#include "Parameters.h" // Assuming this is needed for m_RootSelection, etc.
+
+using namespace std;
+
+// Destructor:
+RCMPPOrdering::~RCMPPOrdering() {
+}
+
+
+
+
+void RCMPPOrdering::sortNeighborsBuckets(unsigned* queue,unsigned   start_v,unsigned   qe,double*    sort_values)
+{
+    unsigned count = qe - start_v;
+
+    // --- Fallback: insertion sort for tiny batches ---
+    if (count <= SMALL_SORT_THRESHOLD) {
+        for (unsigned i = start_v; i < qe; ++i) {
+            unsigned j = i;
+            while (j > start_v && sort_values[queue[j]] > sort_values[queue[j - 1]]) {
+                unsigned tmp  = queue[j];
+                queue[j] = queue[j - 1];
+                queue[j - 1]  = tmp;
+                --j;
+            }
+        }
+        return;
+    }
+
+    // --- Find degree range in this batch ---
+    double min_deg = sort_values[queue[start_v]];
+    double max_deg = sort_values[queue[start_v]];
+    for (unsigned i = start_v + 1; i < qe; ++i) {
+        double d = sort_values[queue[i]];
+        if (d < min_deg) min_deg = d;
+        if (d > max_deg) max_deg = d;
+    }
+
+    // All neighbours have identical degree — nothing to sort.
+    if (min_deg == max_deg) return;
+
+    const double range = max_deg - min_deg;
+    const double bucket_scale = static_cast<double>(NUM_SORT_BUCKETS - 1);
+
+   // In social networks, the peripheral nodes have near-identical eccentricity. So using log-scale mapping would give more accurate results.
+   const double log_range = std::log(range + 1.0);
+   auto degToBucket = [&](double d) -> int {
+        int b = static_cast<int>(std::log(max_deg - d + 1.0) / log_range * bucket_scale);
+        if (b < 0) b = 0;                      
+        if (b >= (int)NUM_SORT_BUCKETS) b = NUM_SORT_BUCKETS - 1;
+        return b;
+    };
+    
+    
+    // --- Count pass: how many nodes land in each bucket? ---
+    // Bucket 0 holds the HIGHEST degrees (descending output order).
+    unsigned bucket_counts[NUM_SORT_BUCKETS] = {};
+    for (unsigned i = start_v; i < qe; ++i) {
+        ++bucket_counts[degToBucket(sort_values[queue[i]])];
+    }
+    
+    // --- Prefix sums write-position per bucket (relative to temp[0]) ---
+    unsigned write_pos[NUM_SORT_BUCKETS];
+    write_pos[0] = 0;
+    for (unsigned b = 1; b < NUM_SORT_BUCKETS; ++b)
+        write_pos[b] = write_pos[b - 1] + bucket_counts[b - 1];
+
+    // --- Scatter pass into temporary buffer ---
+    vector<unsigned> temp(count);
+    for (unsigned i = start_v; i < qe; ++i) {
+        unsigned node = queue[i];
+        temp[write_pos[degToBucket(sort_values[node])]++] = node;
+    }
+
+    // --- Copy back into queue ---
+    for (unsigned i = 0; i < count; ++i)
+        queue[start_v + i] = temp[i];
+}
+
+
+
+// --- Helper Functions for BNF/GL Logic ---
+
+/**
+ * @brief Performs Breadth-First Search (BFS) to construct the level structure.
+ * @param start_node The vertex to start the BFS from.
+ * @param queue Pointer to the array where the ordered nodes are stored.
+ * @param level Pointer to the array storing the level (distance from start_node) of each node.
+ * @param ccsize Output: The size of the connected component found.
+ * @param final_level Output: The eccentricity (depth) of the start_node.
+ */
+void RCMPPOrdering::runBFS(unsigned start_node, unsigned* queue, int* level, unsigned& ccsize, int& final_level) {
+  unsigned* ptrs = this->getMatrix().getPtr();
+  unsigned* ids = this->getMatrix().getInd();
+  
+  queue[0] = start_node;
+  level[start_node] = 0;
+  unsigned qs = 0;
+  unsigned qe = 1;
+
+  int clevel = 0;
+  while(qs < qe) {
+    unsigned v = queue[qs++];
+    clevel = level[v];
+    for(unsigned ptr = ptrs[v]; ptr < ptrs[v+1]; ptr++) {
+      unsigned nbr = ids[ptr];
+      // Only visit unvisited nodes (level == -1)
+      if(level[nbr] == -1) { 
+        level[nbr] = clevel + 1;
+        queue[qe++] = nbr;
+      }
+    }
+  }
+  ccsize = qe;
+  final_level = (ccsize > 0) ? level[queue[qe-1]] : -1;
+}
+
+
+void RCMPPOrdering::resetLevels(unsigned* queue, int* level, unsigned ccsize) {
+    for (unsigned i = 0; i < ccsize; i++)
+        level[queue[i]] = -1;
+}
+
+
+/**
+ * @brief Finds the node with the minimum degree on the deepest level L_epsilon(v) (George-Liu step).
+ * @param queue The array containing nodes of the connected component ordered by BFS.
+ * @param level The array of node levels.
+ * @param ccsize The size of the connected component.
+ * @param final_level The deepest level (eccentricity).
+ * @return unsigned The node on the deepest level with the minimum degree.
+ */
+unsigned RCMPPOrdering::findMinDegreeNodeOnDeepestLevel(unsigned* queue, int* level, unsigned ccsize, int final_level) {
+    unsigned* ptrs = this->getMatrix().getPtr();
+    
+    if (ccsize == 0 || final_level < 0) return 0;
+
+    unsigned best_root = 0; 
+    unsigned min_degree = (unsigned)-1; 
+
+    // Iterate backwards through the queue to find all nodes at the deepest level (L_epsilon(v))
+    for (unsigned i = ccsize - 1; i < ccsize; i--) { 
+      unsigned v = queue[i];
+      if (level[v] < final_level) {
+          break; // We've moved past the deepest level
+      }
+      
+      unsigned current_degree = ptrs[v+1] - ptrs[v];
+      if(current_degree < min_degree) {
+        min_degree = current_degree;
+        best_root = v;
+      }
+      if (i == 0) break; 
+    }   
+    return best_root;
+}
+
+/**
+ * @brief Calculates the width of the level structure (the size of the largest level).
+ * @param queue The array containing nodes of the connected component ordered by BFS.
+ * @param level The array of node levels.
+ * @param ccsize The size of the connected component.
+ * @param final_level The deepest level (eccentricity).
+ * @return double The maximum size of any level in the structure.
+ */
+double RCMPPOrdering::calculateWidth(unsigned* queue, int* level, unsigned ccsize, int final_level) {
+    if (ccsize <= 1) return 1.0;
+
+    int num_levels = final_level + 1;
+    std::vector<unsigned> level_sizes(num_levels, 0); 
+    
+    // Count nodes in each level
+    for(unsigned i = 0; i < ccsize; i++) {
+        unsigned node = queue[i];
+        int l = level[node];
+        if (l >= 0 && l < num_levels) {
+            level_sizes[l]++;
+        }
+    }
+
+    // Find the maximum size (the width)
+    double max_size = 0.0;
+    for(unsigned size : level_sizes) {
+        if((double)size > max_size) {
+            max_size = (double)size;
+        }
+    }
+    return max_size;
+}
+
+// --- Original RCM function (Cuthill-McKee part) ---
+
+void RCMPPOrdering::rcm (   unsigned& root, unsigned* queue,
+                          double* sort_values,
+                          bool* is_permuted) {
+  unsigned* ptrs = this->getMatrix().getPtr();
+  unsigned* ids = this->getMatrix().getInd();
+  
+  queue[0] = root;
+  unsigned qs = 0;
+  unsigned qe = 1;
+
+  // Define the threshold for sorting
+  const double SORT_THRESHOLD = 10.0;
+
+  while(qs < qe) {
+    unsigned v = queue[qs++];
+    unsigned start_v = qe;
+    unsigned high_deg_marker = qe;
+
+    for(unsigned ptr = ptrs[v]; ptr < ptrs[v+1]; ptr++) {
+      unsigned nbr = ids[ptr];
+
+      if(!is_permuted[nbr]) {
+        is_permuted[nbr] = true;
+
+        if (sort_values[nbr] >= SORT_THRESHOLD) {
+          // 1. Move a lower-degree placeholder to the end
+          unsigned temp = queue[high_deg_marker];
+          queue[qe++] = temp;
+          // 2. Insert high-degree neighbor into the sortable segment
+          queue[high_deg_marker++] = nbr;
+        } else {
+          // Insert low-degree neighbor at the end (will not be sorted)
+          queue[qe++] = nbr;
+        }
+      } 
+    }
+
+    // Sort ONLY the neighbors that exceeded the degree threshold
+    if(high_deg_marker > start_v) {
+        sortNeighborsBuckets(queue, start_v, high_deg_marker, sort_values);
+    }
+  }
+}
+
+// --- Main Ordering Function (RCM++) ---
+void RCMPPOrdering::orderingFunction() {
+  unsigned n = this->getMatrix().getRowCount();
+  unsigned* ptrs = this->getMatrix().getPtr();
+  unsigned* ids = this->getMatrix().getInd();
+
+  rowIPermutation = new unsigned[n];
+  colIPermutation = new unsigned[n];
+
+  unsigned* queue = new unsigned[n];
+  int* level = new int[n];
+  double* sort_values = new double[n];
+  bool* is_permuted = new bool [n];
+  
+  // Initialize state
+  for (unsigned i = 0; i < n; i++) {
+    level[i] = -1;
+    is_permuted[i] = false;
+    // Default sorting criteria: Degree
+    if(m_SortingCriteria == "DEG") {
+      sort_values[i] = (double)(ptrs[i + 1] - ptrs[i]);
+    } else {
+      sort_values[i] = 0.0; 
+    }
+  }
+
+  unsigned total_permuted = 0;
+
+  for (unsigned i = 0; i < n; i++) { 
+    if (!is_permuted[i]) { 
+      unsigned current_root = i;
+      int max_eccentricity = -1;
+      unsigned ccsize = 0;
+      unsigned* current_queue_start = queue + total_permuted;
+      
+      double recordWidth = std::numeric_limits<double>::max();
+      unsigned recordedNode = i;
+
+      // Handle isolated nodes or self-loops
+      if(ptrs[i+1] == ptrs[i] || ((ptrs[i+1] == ptrs[i] + 1) && ids[ptrs[i]] == i)) {
+        ccsize = 1;
+        current_queue_start[0] = i;
+        is_permuted[i] = true;
+      } else {
+        // --- BNF / George-Liu Root Selection ---
+        unsigned next_root = current_root;
+	int iterations = 0;
+	const int MAX_BNF_ITERATIONS = 5;
+        while(iterations < MAX_BNF_ITERATIONS) {
+	  iterations++;
+          current_root = next_root;
+          int current_eccentricity;
+          
+          runBFS(current_root, current_queue_start, level, ccsize, current_eccentricity); 
+          double current_width = calculateWidth(current_queue_start, level, ccsize, current_eccentricity);
+          for(unsigned j = 0; j < ccsize; j++) {
+            is_permuted[current_queue_start[j]] = true; 
+          }
+          
+	  
+	  if(current_eccentricity > max_eccentricity) {
+            max_eccentricity = current_eccentricity;
+            recordWidth = current_width;
+            recordedNode = current_root;
+          } else if (current_eccentricity == max_eccentricity) {
+            if (current_width < recordWidth) {
+              recordWidth = current_width;
+              recordedNode = current_root;
+            }
+          }
+
+          next_root = findMinDegreeNodeOnDeepestLevel(current_queue_start, level, ccsize, current_eccentricity);
+          resetLevels(current_queue_start, level, ccsize);		 
+          
+          if (!m_RootSelection) { recordedNode = i; break; }
+          if (next_root == current_root) break; 
+          if (current_eccentricity < max_eccentricity) break; 
+        
+	  if (next_root == current_root) break; 
+    	  if (current_eccentricity <= max_eccentricity) break;
+	
+	} 
+
+        // --- Small World Optimization ---
+        bool small_world = (ccsize > 1) && (max_eccentricity < static_cast<int>(std::log2(static_cast<double>(ccsize))));
+        if (small_world && m_RootSelection) {
+          int dummy_sw;
+          runBFS(i, current_queue_start, level, ccsize, dummy_sw);
+          resetLevels(current_queue_start, level, ccsize);
+ 
+          unsigned min_deg_node = current_queue_start[0];
+          unsigned min_deg = ptrs[min_deg_node + 1] - ptrs[min_deg_node];
+          for (unsigned j = 1; j < ccsize; ++j) {
+            unsigned v = current_queue_start[j];
+            unsigned dv = ptrs[v + 1] - ptrs[v];
+            if (dv < min_deg) { min_deg = dv; min_deg_node = v; }
+          }
+          recordedNode = min_deg_node;
+        }
+	
+        // --- Final RCM Step for this Component ---
+        // Clean the is_permuted flags for this specific component before RCM traversal
+        for(unsigned j = 0; j < ccsize; j++) {
+            is_permuted[current_queue_start[j]] = false;
+        }
+
+        current_root = recordedNode; 
+        is_permuted[current_root] = true; // Mark root for RCM
+        rcm(current_root, current_queue_start, sort_values, is_permuted); 
+
+        // --- Reversal & Mapping (The Fix) ---
+        // Reverse ONLY this component to minimize bandwidth
+        for (unsigned j = 0; j < ccsize / 2; j++) {
+            std::swap(current_queue_start[j], current_queue_start[ccsize - 1 - j]);
+        }
+      }
+     
+      // Assign final permutation indices for this component
+      for (unsigned j = 0; j < ccsize; j++) {
+          unsigned node = current_queue_start[j];
+          rowIPermutation[node] = total_permuted + j;
+          colIPermutation[node] = total_permuted + j;
+      }
+
+      total_permuted += ccsize;    
+    }
+  }
+
+  delete [] queue;
+  delete [] level;
+  delete [] sort_values;
+  delete [] is_permuted;
+}


### PR DESCRIPTION
Adds matrix ordering implementations developed over the past year:
DRSA: Recursively bisects the matrix graph using Fiedler vectors to reduce bandwidth and improve cache locality.
RCM++: Extends classic RCM with better pseudo-peripheral node selection for tighter bandwidth reduction on irregular sparsity patterns.